### PR TITLE
Fix passage loading after generation and add markdown parsing

### DIFF
--- a/src/components/generation/DebugPanel.tsx
+++ b/src/components/generation/DebugPanel.tsx
@@ -4,6 +4,7 @@ import { api, type GenerationLog, type GenerationLogSummary } from '@/lib/api'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
 import { ScrollArea } from '@/components/ui/scroll-area'
+import { StreamMarkdown } from '@/components/ui/stream-markdown'
 import { X, ChevronDown, ChevronRight } from 'lucide-react'
 
 interface DebugPanelProps {
@@ -276,8 +277,8 @@ function OutputTab({ log }: { log: GenerationLog }) {
           {log.generatedText.length.toLocaleString()} chars
         </span>
       </div>
-      <div className="prose-content whitespace-pre-wrap bg-card/30 rounded-lg p-6 border border-border/20">
-        {log.generatedText}
+      <div className="bg-card/30 rounded-lg p-6 border border-border/20">
+        <StreamMarkdown content={log.generatedText} />
       </div>
     </div>
   )

--- a/src/components/generation/GenerationPanel.tsx
+++ b/src/components/generation/GenerationPanel.tsx
@@ -3,6 +3,7 @@ import { useQueryClient } from '@tanstack/react-query'
 import { api } from '@/lib/api'
 import { Button } from '@/components/ui/button'
 import { Textarea } from '@/components/ui/textarea'
+import { StreamMarkdown } from '@/components/ui/stream-markdown'
 import { DebugPanel } from './DebugPanel'
 import { Send, Eye, Square, Bug, ArrowLeft } from 'lucide-react'
 
@@ -102,12 +103,7 @@ export function GenerationPanel({ storyId, onBack }: GenerationPanelProps) {
             <>
               <div ref={outputRef} className="flex-1 overflow-auto px-6 py-6">
                 <div className="max-w-[38rem] mx-auto">
-                  <div className="prose-content whitespace-pre-wrap">
-                    {streamedText}
-                  </div>
-                  {isGenerating && (
-                    <span className="inline-block w-0.5 h-[1.1em] bg-primary/60 animate-pulse ml-px align-text-bottom" />
-                  )}
+                  <StreamMarkdown content={streamedText} streaming={isGenerating} />
                 </div>
               </div>
               <div className="h-px bg-border/30" />

--- a/src/components/prose/ProseChainView.tsx
+++ b/src/components/prose/ProseChainView.tsx
@@ -4,6 +4,7 @@ import { api, type Fragment } from '@/lib/api'
 import { Button } from '@/components/ui/button'
 import { Textarea } from '@/components/ui/textarea'
 import { ScrollArea } from '@/components/ui/scroll-area'
+import { StreamMarkdown } from '@/components/ui/stream-markdown'
 import { ProseActionInput } from '@/components/prose/ProseActionInput'
 import { VariationSwitcher } from '@/components/prose/VariationSwitcher'
 import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
@@ -27,6 +28,7 @@ export function ProseChainView({
   // State for streaming generation
   const [isGenerating, setIsGenerating] = useState(false)
   const [streamedText, setStreamedText] = useState('')
+  const [fragmentCountBeforeGeneration, setFragmentCountBeforeGeneration] = useState<number | null>(null)
   const [followGeneration, setFollowGeneration] = useState(() => {
     if (typeof window === 'undefined') return true
     const saved = localStorage.getItem(FOLLOW_GENERATION_KEY)
@@ -90,19 +92,23 @@ export function ProseChainView({
 
   // Clear streamed text once fragments update (new prose was saved)
   useEffect(() => {
-    if (!isGenerating && streamedText) {
-      // Check if the last fragment's content matches our streamed text
-      // or if a new fragment was added while we were generating
+    if (!isGenerating && streamedText && fragmentCountBeforeGeneration !== null) {
+      // Check if a new fragment was added (count increased) or if the last fragment's content matches
+      const currentCount = orderedFragments.length
       const lastFragment = orderedFragments[orderedFragments.length - 1]
-      if (lastFragment && (lastFragment.content === streamedText || lastFragment.meta?.generatedFrom)) {
+      
+      // Clear if fragment count increased (new fragment added) or content matches
+      if (currentCount > fragmentCountBeforeGeneration ||
+          (lastFragment && lastFragment.content === streamedText)) {
         // Give a small delay so the transition is smooth
         const timeout = setTimeout(() => {
           setStreamedText('')
+          setFragmentCountBeforeGeneration(null)
         }, 100)
         return () => clearTimeout(timeout)
       }
     }
-  }, [orderedFragments, isGenerating, streamedText])
+  }, [orderedFragments, isGenerating, streamedText, fragmentCountBeforeGeneration])
 
   // Track which prose block is currently visible
   useEffect(() => {
@@ -175,12 +181,7 @@ export function ProseChainView({
             <div className="relative mb-6 animate-in fade-in slide-in-from-bottom-2 duration-300" data-component-id="prose-streaming-block">
               {/* Match prose block styling - no border, minimal background */}
               <div className="rounded-lg p-4 -mx-4 bg-card/30">
-                <div className="prose-content whitespace-pre-wrap">
-                  {streamedText}
-                  {isGenerating && (
-                    <span className="inline-block w-0.5 h-[1.1em] bg-primary/60 animate-pulse ml-px align-text-bottom" />
-                  )}
-                </div>
+                <StreamMarkdown content={streamedText} streaming={isGenerating} />
 
                 {/* Minimal generating indicator matching prose metadata bar style */}
                 {isGenerating && (
@@ -201,6 +202,7 @@ export function ProseChainView({
             onGenerationStart={() => {
               setIsGenerating(true)
               setStreamedText('')
+              setFragmentCountBeforeGeneration(orderedFragments.length)
             }}
             onGenerationStream={(text) => setStreamedText(text)}
             onGenerationComplete={() => {
@@ -891,15 +893,13 @@ function ProseBlock({
         className="text-left w-full rounded-lg p-4 -mx-4 transition-colors duration-150 hover:bg-card/40 cursor-pointer"
         data-component-id={`prose-${fragment.id}-select`}
       >
-        <div className="prose-content whitespace-pre-wrap">
-          {(isStreamingAction || streamedActionText)
+        <StreamMarkdown
+          content={(isStreamingAction || streamedActionText)
             ? streamedActionText || ''
             : fragment.content
           }
-          {isStreamingAction && (
-            <span className="inline-block w-0.5 h-[1.1em] bg-primary/60 animate-pulse ml-px align-text-bottom" />
-          )}
-        </div>
+          streaming={isStreamingAction}
+        />
 
         {/* Metadata bar — visible on hover */}
         <div className="flex items-center gap-2 mt-3 pt-2 opacity-0 group-hover:opacity-100 transition-opacity duration-150">


### PR DESCRIPTION
This PR fixes two issues with prose display:

1. **Passage loading bug**: After generating a new passage, the prose chain would display the previous passage instead of the newly generated one until a manual page refresh. This was caused by the streaming text clearing effect running before the fragments query refreshed. Fixed by tracking the fragment count before generation and only clearing streamed text when the count actually increases.

2. **Missing markdown parsing**: Prose content was displayed as plain text, so markdown formatting like `*italics*` and `**bold**` wasn't rendered. Fixed by using the existing `StreamMarkdown` component in all prose display areas:
   - `ProseChainView` - for streaming text and fragment content
   - `GenerationPanel` - for preview output
   - `DebugPanel` - for generated text in debug logs