### PR TITLE
fix(wizard): auto-select first model after fetching model list

### DIFF
--- a/src/components/onboarding/OnboardingWizard.tsx
+++ b/src/components/onboarding/OnboardingWizard.tsx
@@ -661,6 +661,10 @@ function ProviderSetupStep({
       } else {
         setFetchedModels(result.models)
         setUseCustomModel(false)
+        // Auto-select first model if current selection is empty or not in the list
+        if (result.models.length > 0 && (!defaultModel || !result.models.some(m => m.id === defaultModel))) {
+          setDefaultModel(result.models[0].id)
+        }
       }
     } catch (err) {
       setFetchError(err instanceof Error ? err.message : 'Failed to fetch models')

--- a/src/components/settings/ProviderManager.tsx
+++ b/src/components/settings/ProviderManager.tsx
@@ -176,6 +176,10 @@ export function ProviderPanel({ onClose }: { onClose: () => void }) {
       } else {
         setFetchedModels(result.models)
         setUseCustomModel(false)
+        // Auto-select first model if current selection is empty or not in the list
+        if (form && result.models.length > 0 && (!form.defaultModel || !result.models.some(m => m.id === form.defaultModel))) {
+          setForm({ ...form, defaultModel: result.models[0].id })
+        }
       }
     } catch (err) {
       setFetchError(err instanceof Error ? err.message : 'Failed to fetch models')


### PR DESCRIPTION
When fetching models, the dropdown visually showed the first model but the state remained empty, keeping Save & Continue and Test buttons disabled. Now auto-selects the first fetched model when the current selection is empty or not in the list. Fixed in both OnboardingWizard and ProviderManager.