### PR TITLE
build: add devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,26 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/ubuntu
+{
+	"name": "Ubuntu",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	"image": "mcr.microsoft.com/devcontainers/base:noble",
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	"features": {
+		"ghcr.io/devcontainers-extra/features/bun:1": {}
+	},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	"postCreateCommand": "sudo apt-get -q update && sudo apt-get -q upgrade --no-install-recommends --autoremove --yes && bun install --frozen-lockfile",
+
+	// Configure tool-specific properties.
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"oven.bun-vscode"
+			]
+		}
+	}
+}


### PR DESCRIPTION
[Development Containers](https://containers.dev/) make it somewhat easier to get a dev environment running and provide some measure of protection against supply chain attacks exploiting the developer's system.

Nothing too tricky in this one. Just light customization on top of the default Ubuntu container for VS Code.