### PR TITLE
fix(fragments): correct cache invalidation to show newly created fragments in fragment list without reload

### DIFF
--- a/src/components/fragments/FragmentEditor.tsx
+++ b/src/components/fragments/FragmentEditor.tsx
@@ -126,8 +126,8 @@ export function FragmentEditor({
     }
   }, [sourceFragment, createType, prefill, fragmentProp?.id])
 
-  const invalidate = async () => {
-    const fType = fragment?.type
+  const invalidate = async (overrideType?: string) => {
+    const fType = overrideType ?? fragment?.type
     const promises: Promise<void>[] = [
       queryClient.invalidateQueries({ queryKey: ['fragments-archived', storyId] }),
     ]
@@ -153,7 +153,7 @@ export function FragmentEditor({
     mutationFn: (data: { type: string; name: string; description: string; content: string }) =>
       api.fragments.create(storyId, data),
     onSuccess: (created) => {
-      invalidate()
+      invalidate(created.type)
       onSaved(created)
     },
   })


### PR DESCRIPTION
This fixes fragments created by the + create button in the fragment editor not showing up until the component was reloaded.

Fix:
- The invalidate() function was failing to clear the specific React Query cache list (['fragments', storyId, type]) because the fragment prop is null during creation, making fragment.type undefined.
- Updated invalidate() to accept an optional overrideType parameter.
- Modified createMutation.onSuccess to pass the newly created.type to invalidate(), ensuring the fragment list cache is properly cleared and immediately displays the new item.