### PR TITLE
refactor(ui): auto-resizing for librarian and character chat input textareas

### DIFF
--- a/src/components/character-chat/CharacterChatView.tsx
+++ b/src/components/character-chat/CharacterChatView.tsx
@@ -96,6 +96,14 @@ export function CharacterChatView({ storyId, initialCharacterId, onClose }: Char
     }
   }, [messages, scrollToBottom])
 
+  // Auto-resize textarea
+  useEffect(() => {
+    const el = textareaRef.current
+    if (!el) return
+    el.style.height = 'auto'
+    el.style.height = Math.min(el.scrollHeight, 400) + 'px'
+  }, [input])
+
   // Handle character change — reset conversation
   const handleCharacterChange = useCallback((id: string) => {
     setCharacterId(id)
@@ -368,7 +376,7 @@ export function CharacterChatView({ storyId, initialCharacterId, onClose }: Char
                   : 'Select a character first...'
               }
               disabled={isStreaming || !characterId}
-              className="min-h-[44px] max-h-[140px] resize-none text-[0.8125rem] bg-transparent
+              className="min-h-[44px] max-h-[400px] resize-none text-[0.8125rem] bg-transparent
                 placeholder:italic placeholder:text-muted-foreground flex-1 border-border/30
                 focus-visible:ring-primary/20"
               rows={1}

--- a/src/components/librarian/LibrarianChat.tsx
+++ b/src/components/librarian/LibrarianChat.tsx
@@ -108,6 +108,14 @@ export function LibrarianChat({ storyId, conversationId, initialInput }: Librari
     }
   }, [messages, scrollToBottom])
 
+  // Auto-resize textarea
+  useEffect(() => {
+    const el = textareaRef.current
+    if (!el) return
+    el.style.height = 'auto'
+    el.style.height = Math.min(el.scrollHeight, 400) + 'px'
+  }, [input])
+
   const handleSend = useCallback(async () => {
     const text = input.trim()
     if (!text || isStreaming) return
@@ -263,7 +271,7 @@ export function LibrarianChat({ storyId, conversationId, initialInput }: Librari
             onKeyDown={handleKeyDown}
             placeholder="Ask the librarian..."
             disabled={isStreaming}
-            className="min-h-[40px] max-h-[120px] resize-none text-xs bg-transparent placeholder:italic placeholder:text-muted-foreground flex-1"
+            className="min-h-[40px] max-h-[400px] resize-none text-xs bg-transparent placeholder:italic placeholder:text-muted-foreground flex-1"
             rows={1}
             data-component-id="librarian-chat-input"
           />


### PR DESCRIPTION
Adds smooth auto-resizing for the input textareas in both the Librarian and Character chats.
Just like in `InlineGenerationInput` the input field grows up to its maximum height with more text.
Previously, these textareas didn't resize at all and stayed at single row height regardless of how much text was added.

Currently duplicates the `useEffect` hook in `InlineGenerationInput`. Can also make this into a reusable custom hook.

Changes:
- Added a `useEffect` to `LibrarianChat.tsx` and `CharacterChatView.tsx` that binds the textarea's `style.height` to its `scrollHeight`.