### PR TITLE
feat(sidebar): wire Block Editor into management panel

### DIFF
--- a/src/components/sidebar/DetailPanel.tsx
+++ b/src/components/sidebar/DetailPanel.tsx
@@ -9,6 +9,7 @@ import { AgentsPanel } from '@/components/agents/AgentsPanel'
 import { StoryInfoPanel } from './StoryInfoPanel'
 import { SettingsPanel } from './SettingsPanel'
 import { LibrarianPanel } from './LibrarianPanel'
+import { BlockEditorPanel } from '@/components/blocks/BlockEditorPanel'
 import { ArchivePanel } from './ArchivePanel'
 import { TimelineManagerPanel } from './TimelineManagerPanel'
 import { Button } from '@/components/ui/button'
@@ -56,6 +57,7 @@ const SECTION_TITLES: Record<string, string> = {
   archive: 'Archive',
   branches: 'Timelines',
   'context-order': 'Fragment Order',
+  blocks: 'Block Editor',
   agents: 'Agents',
   settings: 'Settings',
   'agent-activity': 'Librarian',
@@ -165,6 +167,10 @@ export function DetailPanel({
 
       {activeSection === 'agents' && (
         <AgentsPanel storyId={storyId} />
+      )}
+
+      {activeSection === 'blocks' && (
+        <BlockEditorPanel storyId={storyId} />
       )}
 
       {activeSection === 'context-order' && (

--- a/src/components/sidebar/StorySidebar.tsx
+++ b/src/components/sidebar/StorySidebar.tsx
@@ -49,6 +49,7 @@ export type SidebarSection =
   | 'archive'
   | 'branches'
   | 'context-order'
+  | 'blocks'
   | 'agents'
   | 'settings'
   | 'agent-activity'
@@ -253,6 +254,21 @@ export function StorySidebar({
                   >
                     <ArrowUpDown className="size-4" />
                     <span>Fragment Order</span>
+                    <ChevronRight className="ml-auto size-3.5 text-muted-foreground" />
+                  </SidebarMenuButton>
+                </SidebarMenuItem>
+              )}
+
+              {story?.settings.contextOrderMode === 'advanced' && (
+                <SidebarMenuItem>
+                  <SidebarMenuButton
+                    isActive={activeSection === 'blocks'}
+                    onClick={() => handleToggle('blocks')}
+                    tooltip="Block Editor"
+                    data-component-id="sidebar-section-blocks"
+                  >
+                    <Wrench className="size-4" />
+                    <span>Block Editor</span>
                     <ChevronRight className="ml-auto size-3.5 text-muted-foreground" />
                   </SidebarMenuButton>
                 </SidebarMenuItem>


### PR DESCRIPTION
## Summary

I noticed the Advanced setting does not add the Block Editor selector to the sidebar menu. This PR adds Block Editor access to the sidebar when advanced prompt control is enabled.

## Changes

- adds `blocks` to `SidebarSection`
- adds Block Editor menu item in the management section
- wires `BlockEditorPanel` into `DetailPanel`
- adds Block Editor section title

## Result

The existing Block Editor UI is now reachable from the sidebar when `contextOrderMode === 'advanced'`.

## Notes

This change only exposes the existing UI. It does not change Block Editor behavior. These changes were aided by ChatGPT.