### PR TITLE
refactor(llm): inline renderBlock and drop getFullProseChain alias

### DIFF
--- a/src/server/llm/context-builder.ts
+++ b/src/server/llm/context-builder.ts
@@ -1,7 +1,7 @@
 import { getStory, listFragments, getFragment } from '../fragments/storage'
 import { registry } from '../fragments/registry'
 import { createLogger } from '../logging'
-import { getActiveProseIds, findSectionIndex, getFullProseChain } from '../fragments/prose-chain'
+import { getActiveProseIds, findSectionIndex, getProseChain } from '../fragments/prose-chain'
 import { getAnalysis, getLatestAnalysisIdsByFragment } from '../librarian/storage'
 import type { Fragment, StoryMeta } from '../fragments/schema'
 import type { ModelMessage } from 'ai'
@@ -274,7 +274,7 @@ export async function buildContextState(
 
   let chapterSummaries: Array<{ markerId: string; name: string; summary: string }> = []
   if (story.settings.enableHierarchicalSummary && activeProseIds.length > 0 && recentProse.length > 0) {
-    const chain = await getFullProseChain(dataDir, storyId)
+    const chain = await getProseChain(dataDir, storyId)
     if (chain) {
       const sectionByFragmentId = new Map(activeProseIds.map((id, idx) => [id, idx]))
       const recentSectionIndexes = recentProse
@@ -659,13 +659,6 @@ export function createDefaultBlocks(state: ContextBuildState, opts: AssembleOpti
 }
 
 /**
- * Renders a single block: prepends the [@block=id] marker to its content.
- */
-function renderBlock(block: ContextBlock): string {
-  return `[@block=${block.id}]\n${block.content}`
-}
-
-/**
  * Compiles context blocks into LLM messages.
  * Groups blocks by role, sorts by order, prepends [@block=id] markers,
  * and joins with blank-line separators.
@@ -675,18 +668,19 @@ export function compileBlocks(blocks: ContextBlock[]): ContextMessage[] {
   const userBlocks = blocks.filter(b => b.role === 'user').sort((a, b) => a.order - b.order)
 
   const messages: ContextMessage[] = []
+  const render = (b: ContextBlock) => `[@block=${b.id}]\n${b.content}`
 
   if (systemBlocks.length > 0) {
     messages.push({
       role: 'system',
-      content: systemBlocks.map(renderBlock).join('\n\n'),
+      content: systemBlocks.map(render).join('\n\n'),
     })
   }
 
   if (userBlocks.length > 0) {
     messages.push({
       role: 'user',
-      content: userBlocks.map(renderBlock).join('\n\n'),
+      content: userBlocks.map(render).join('\n\n'),
     })
   }
 


### PR DESCRIPTION
## Summary

Unit 1 of a parallel backend simplification batch. Scope: `src/server/llm/context-builder.ts` plus a claimed-deletable sibling file.

## Files changed

- `src/server/llm/context-builder.ts` (+5 / -11)

## What was done

1. **Inlined `renderBlock`** into its sole caller `compileBlocks` as a local arrow function. The helper was a one-liner (`[@block=\${id}]\n\${content}`) used twice inside `compileBlocks` and nowhere else.
2. **Replaced `getFullProseChain` with `getProseChain`** in the one call site inside `buildContextState`. The former is a trivial pass-through slated for removal by Unit 5; the call sites have identical signatures.

## What was NOT done (scope revisions)

The task brief also listed these as candidates, but pre-flight grep found active importers, so per the brief's own stop-rule I did not delete them:

- **`assembleMessages`** — imported in `tests/llm/context-builder.test.ts` (lines 17, 1038, 1064).
- **`buildContext`** — imported in `tests/llm/context-builder.test.ts` and used by ~20 tests.
- **`compile-generation-writer-context.ts`** — file does not exist in the tree; nothing to delete.
- **`slugify`** — not present in `context-builder.ts`; nothing to inline.

Removing the first two would require coordinated test edits that exceed this unit's scope.

## Verified imports (grep across `src/`, `tests/`, `plugins/`)

- `compile-generation-writer-context` — zero matches (file absent).
- `assembleMessages` — `tests/llm/context-builder.test.ts` + `context-builder.ts` itself.
- `buildContext` (word-boundary, not `buildContextState`) — `tests/llm/context-builder.test.ts` + `context-builder.ts` itself.
- `renderBlock` — only inside `context-builder.ts`'s `compileBlocks` (now inlined).
- `getFullProseChain` — other callers (`src/server/routes/prose-chain.ts`, `src/server/chapters/summarize.ts`) are owned by Unit 5.

## Net line delta

-6 lines.

## Test result

`bun run test`: 462/462 passing (unchanged from pre-refactor baseline in this worktree). The 623 figure mentioned in the brief reflects the post-merge state on `main`; this worktree branches from an earlier commit where the baseline is 462.

## Test plan

- [x] `bun run test` passes locally.
- [ ] Verify in CI.