### PR TITLE
refactor(storage): inline emptyConfig helper in block storage

### DIFF
--- a/src/server/blocks/storage.ts
+++ b/src/server/blocks/storage.ts
@@ -10,19 +10,15 @@ async function blockConfigPath(dataDir: string, storyId: string): Promise<string
   return join(root, 'block-config.json')
 }
 
-function emptyConfig(): BlockConfig {
-  return { customBlocks: [], overrides: {}, blockOrder: [] }
-}
-
 export async function getBlockConfig(dataDir: string, storyId: string): Promise<BlockConfig> {
   const path = await blockConfigPath(dataDir, storyId)
-  if (!existsSync(path)) return emptyConfig()
+  if (!existsSync(path)) return { customBlocks: [], overrides: {}, blockOrder: [] }
 
   try {
     const raw = await readFile(path, 'utf-8')
     return BlockConfigSchema.parse(JSON.parse(raw))
   } catch {
-    return emptyConfig()
+    return { customBlocks: [], overrides: {}, blockOrder: [] }
   }
 }
 


### PR DESCRIPTION
## Summary

Inline the `emptyConfig()` helper in `src/server/blocks/storage.ts`. Single-file helper with two callers in the same file, no exports, no external importers. Inlining removes zero-value indirection.

## Files

- `src/server/blocks/storage.ts` — inlined (-6, +2 = **-4 lines**)
- `src/server/agents/agent-block-storage.ts` — **does not exist in this codebase**; no change

## Test result

`bun run test` — 462/462 passing (41 files).

## Test plan

- [x] `bun run test` passes