### PR TITLE
refactor(config): extract fetchModelsFromProvider helper

### DIFF
--- a/src/server/routes/config.ts
+++ b/src/server/routes/config.ts
@@ -12,6 +12,39 @@ import {
 } from '../config/storage'
 import { ProviderConfigSchema } from '../config/schema'
 
+type ModelEntry = { id: string; owned_by?: string }
+type FetchModelsResult = { models: ModelEntry[]; error?: string }
+
+async function fetchModelsFromProvider(
+  baseURL: string,
+  apiKey: string,
+  customHeaders?: Record<string, string>,
+): Promise<FetchModelsResult> {
+  try {
+    const base = baseURL.replace(/\/+$/, '')
+    const url = /\/v\d+$/.test(base) ? `${base}/models` : `${base}/v1/models`
+    const res = await fetch(url, {
+      headers: {
+        'Authorization': `Bearer ${apiKey}`,
+        ...(customHeaders ?? {}),
+      },
+    })
+    if (!res.ok) {
+      const text = await res.text().catch(() => res.statusText)
+      return { models: [], error: `Failed to fetch models: ${res.status} ${text}` }
+    }
+    const json = await res.json() as { data?: ModelEntry[] }
+    const models = (json.data ?? []).map((m) => ({
+      id: m.id,
+      owned_by: m.owned_by,
+    }))
+    models.sort((a, b) => a.id.localeCompare(b.id))
+    return { models }
+  } catch (err) {
+    return { models: [], error: err instanceof Error ? err.message : 'Unknown error fetching models' }
+  }
+}
+
 export function configRoutes(dataDir: string) {
   return new Elysia()
     .get('/config/providers', async () => {
@@ -116,56 +149,12 @@ export function configRoutes(dataDir: string) {
         set.status = 404
         return { models: [], error: 'Provider not found' }
       }
-      try {
-        const base = provider.baseURL.replace(/\/+$/, '')
-        const url = /\/v\d+$/.test(base) ? `${base}/models` : `${base}/v1/models`
-        const res = await fetch(url, {
-          headers: {
-            'Authorization': `Bearer ${provider.apiKey}`,
-            ...(provider.customHeaders ?? {}),
-          },
-        })
-        if (!res.ok) {
-          const text = await res.text().catch(() => res.statusText)
-          return { models: [], error: `Failed to fetch models: ${res.status} ${text}` }
-        }
-        const json = await res.json() as { data?: Array<{ id: string; owned_by?: string }> }
-        const models = (json.data ?? []).map((m) => ({
-          id: m.id,
-          owned_by: m.owned_by,
-        }))
-        models.sort((a, b) => a.id.localeCompare(b.id))
-        return { models }
-      } catch (err) {
-        return { models: [], error: err instanceof Error ? err.message : 'Unknown error fetching models' }
-      }
+      return fetchModelsFromProvider(provider.baseURL, provider.apiKey, provider.customHeaders)
     })
 
     // Fetch models with arbitrary credentials (for unsaved providers, avoids CORS)
     .post('/config/test-models', async ({ body }) => {
-      try {
-        const base = body.baseURL.replace(/\/+$/, '')
-        const url = /\/v\d+$/.test(base) ? `${base}/models` : `${base}/v1/models`
-        const res = await fetch(url, {
-          headers: {
-            'Authorization': `Bearer ${body.apiKey}`,
-            ...(body.customHeaders ?? {}),
-          },
-        })
-        if (!res.ok) {
-          const text = await res.text().catch(() => res.statusText)
-          return { models: [], error: `Failed to fetch models: ${res.status} ${text}` }
-        }
-        const json = await res.json() as { data?: Array<{ id: string; owned_by?: string }> }
-        const models = (json.data ?? []).map((m) => ({
-          id: m.id,
-          owned_by: m.owned_by,
-        }))
-        models.sort((a, b) => a.id.localeCompare(b.id))
-        return { models }
-      } catch (err) {
-        return { models: [], error: err instanceof Error ? err.message : 'Unknown error fetching models' }
-      }
+      return fetchModelsFromProvider(body.baseURL, body.apiKey, body.customHeaders)
     }, {
       body: t.Object({
         baseURL: t.String(),


### PR DESCRIPTION
## Summary
- Consolidates the duplicated OpenAI-compatible `/models` fetching logic in `src/server/routes/config.ts` into a single file-local `fetchModelsFromProvider(baseURL, apiKey, customHeaders?)` helper.
- Both migrated call sites (2): `GET /config/providers/:providerId/models` and `POST /config/test-models`. Response shape to clients is preserved byte-for-byte (successful responses serialize to `{ "models": [...] }` since the helper's optional `error` is `undefined` and omitted by `JSON.stringify`).
- Deliberately skipped: `POST /config/test-connection` (the audit's third candidate). Its shape differs meaningfully from the models fetchers — it POSTs a chat-completion request body, parses `choices[].message.content`, and returns `{ ok, reply }` / `{ ok: false, error }`. Only the URL trailing-slash / version-prefix pattern is shared, which is not substantial enough to justify a second helper.

## Stats
- Call sites consolidated: 2 (of 3 candidates audited)
- Line delta: +35 / -46 (net -11 lines in the one modified file)
- Tests: `bun run test` — 41 files / 462 tests passed

## Test plan
- [x] `bun run test` passes
- [ ] Manual: hit `GET /config/providers/:id/models` and `POST /config/test-models` against a live provider; confirm `{ models: [...] }` and confirm error envelope `{ models: [], error: "..." }` on bad credentials