### PR TITLE
refactor(llm): dedup capitalize/pluralize helpers

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,51 @@
+# Copilot Instructions for Errata
+
+Errata is an LLM-assisted writing app built around a fragment system. For full project architecture, read `CLAUDE.md` and `PLAN.md`. The section below defines the design language any UI work should respect.
+
+## Design Context
+
+### Users
+
+Errata is for **novelists and RP/chat-fic writers** who take their craft seriously — people writing long-form fiction, world-building over months, caring about prose quality, voice, continuity. They are not casual chat users. Many are power users who will reach into the block editor, configure per-role models, write plugins, or wire up their own system prompts. Some are crossing over from SillyTavern but want an experience that refuses to be SillyTavern.
+
+They reach for Errata when they want to sit down and *write*, with the model as a collaborator rather than a toy or a Swiss Army knife.
+
+### Brand Personality
+
+Three words: **Aesthetic. Utilitarian. Bestseller-in-progress.**
+
+- **Aesthetic** — visibly cared-for. The surface should look like someone chose every glyph.
+- **Utilitarian** — no fluff survives. If something does not serve the act of writing, it does not exist.
+- **Bestseller-in-progress** — ambitious, serious, craft-forward. The tool a writer sits at when they mean business.
+
+Anti-personality: the SillyTavern "something-for-everyone" sprawl. Errata does not aim to serve everyone; it aims to be excellent at being Errata.
+
+### Aesthetic Direction
+
+The emotional goal is **writing with a trusted collaborator in an old, beautiful library.** Warm, bookish, reverent, intimate. Hardback-on-the-desk, not SaaS-in-the-browser.
+
+The existing visual language is strong and stays — **extend it carefully**, don't blow it up:
+
+- **Palette**: warm parchment (light) and deep bronze/umber (dark), OKLCH-based, ochre/amber hue family (~55–75°). Primary sits around `oklch(0.485 0.105 55)` / `oklch(0.765 0.105 65)`.
+- **Typography**: Instrument Serif (display), Newsreader (prose), Outfit (sans UI), JetBrains Mono. Serifs carry the literary identity; sans is strictly utilitarian chrome.
+- **Mark**: the six-petal printer's-ornament asterisk (the errata/footnote glyph). Used with restraint.
+- **Motion vocabulary**: guilloche (banknote/certificate filigree) and "wisps" (ethereal agent-activity breath). Both are earned — they appear around meaningful moments (generation, agent thinking), not as ambient decoration.
+- **Themes**: light and dark are peers, plus a high-contrast mode. Choose per context: long writing sessions at night → dark; morning review → light.
+
+Anti-references:
+
+- SillyTavern's broad-church, settings-everywhere experience.
+- Generic AI-app aesthetics: cyan-on-charcoal, purple-to-blue gradient hero, sparkle icons, "chat bubble" UI.
+- SaaS dashboard chrome: same-size card grids, hero metric blocks, sidebar-stripe callouts, pill-badge overload.
+
+### Design Principles
+
+1. **Quiet craftsmanship over spectacle.** The interface is a library, not a stage. Prefer generous space and refined type to visible effort. Decoration appears only where it is specific and meaningful (the mark, the guilloche, a wisp around an active agent) — never as ambient shine.
+
+2. **Focused, not accommodating.** Errata is opinionated. Not every preference deserves a toggle; not every workflow deserves a mode. Before adding a control, ask whether it belongs in Errata at all. Hiding something is a feature.
+
+3. **Every element earns its ink.** Utilitarian means nothing decorative survives scrutiny. Labels are specific. Icons only where they read faster than words. Panels close when the writer is writing. Chrome retreats; prose is the subject.
+
+4. **Bookish, slightly analog.** Lean into the hardback feel: serif display, warm neutrals tinted toward the brand hue, printer's-ornament motifs, the occasional italic or small-caps used with intent. When a pattern starts to feel like a SaaS dashboard (pills, badges, identical card grids, big stat blocks) — replace it.
+
+5. **Lower the cognitive load, especially for long sessions.** Default views are quiet; density is opened on demand. Progressive disclosure for power features. Respect `prefers-reduced-motion` — guilloche and wisps must degrade gracefully. No flashing, no gratuitous staggered page-load reveals inside the writing surface. The writer should be able to stay in the sentence.

--- a/.impeccable.md
+++ b/.impeccable.md
@@ -1,0 +1,47 @@
+## Design Context
+
+### Users
+
+Errata is for **novelists and RP/chat-fic writers** who take their craft seriously — people writing long-form fiction, world-building over months, caring about prose quality, voice, continuity. They are not casual chat users. Many are power users who will reach into the block editor, configure per-role models, write plugins, or wire up their own system prompts. Some are crossing over from SillyTavern but want an experience that refuses to be SillyTavern.
+
+They reach for Errata when they want to sit down and *write*, with the model as a collaborator rather than a toy or a Swiss Army knife.
+
+### Brand Personality
+
+Three words: **Aesthetic. Utilitarian. Bestseller-in-progress.**
+
+- **Aesthetic** — visibly cared-for. The surface should look like someone chose every glyph.
+- **Utilitarian** — no fluff survives. If something does not serve the act of writing, it does not exist.
+- **Bestseller-in-progress** — ambitious, serious, craft-forward. The tool a writer sits at when they mean business.
+
+Anti-personality: the SillyTavern "something-for-everyone" sprawl. Errata does not aim to serve everyone; it aims to be excellent at being Errata.
+
+### Aesthetic Direction
+
+The emotional goal is **writing with a trusted collaborator in an old, beautiful library.** Warm, bookish, reverent, intimate. Hardback-on-the-desk, not SaaS-in-the-browser.
+
+The existing visual language is strong and stays — **extend it carefully**, don't blow it up:
+
+- **Palette**: warm parchment (light) and deep bronze/umber (dark), OKLCH-based, ochre/amber hue family (~55–75°). Primary sits around `oklch(0.485 0.105 55)` / `oklch(0.765 0.105 65)`.
+- **Typography**: Instrument Serif (display), Newsreader (prose), Outfit (sans UI), JetBrains Mono. Serifs carry the literary identity; sans is strictly utilitarian chrome.
+- **Mark**: the six-petal printer's-ornament asterisk (the errata/footnote glyph). Used with restraint.
+- **Motion vocabulary**: guilloche (banknote/certificate filigree) and "wisps" (ethereal agent-activity breath). Both are earned — they appear around meaningful moments (generation, agent thinking), not as ambient decoration.
+- **Themes**: light and dark are peers, plus a high-contrast mode. Choose per context: long writing sessions at night → dark; morning review → light.
+
+Anti-references:
+
+- SillyTavern's broad-church, settings-everywhere experience.
+- Generic AI-app aesthetics: cyan-on-charcoal, purple-to-blue gradient hero, sparkle icons, "chat bubble" UI.
+- SaaS dashboard chrome: same-size card grids, hero metric blocks, sidebar-stripe callouts, pill-badge overload.
+
+### Design Principles
+
+1. **Quiet craftsmanship over spectacle.** The interface is a library, not a stage. Prefer generous space and refined type to visible effort. Decoration appears only where it is specific and meaningful (the mark, the guilloche, a wisp around an active agent) — never as ambient shine.
+
+2. **Focused, not accommodating.** Errata is opinionated. Not every preference deserves a toggle; not every workflow deserves a mode. Before adding a control, ask whether it belongs in Errata at all. Hiding something is a feature.
+
+3. **Every element earns its ink.** Utilitarian means nothing decorative survives scrutiny. Labels are specific. Icons only where they read faster than words. Panels close when the writer is writing. Chrome retreats; prose is the subject.
+
+4. **Bookish, slightly analog.** Lean into the hardback feel: serif display, warm neutrals tinted toward the brand hue, printer's-ornament motifs, the occasional italic or small-caps used with intent. When a pattern starts to feel like a SaaS dashboard (pills, badges, identical card grids, big stat blocks) — replace it.
+
+5. **Lower the cognitive load, especially for long sessions.** Default views are quiet; density is opened on demand. Progressive disclosure for power features. Respect `prefers-reduced-motion` — guilloche and wisps must degrade gracefully. No flashing, no gratuitous staggered page-load reveals inside the writing surface. The writer should be able to stay in the sentence.

--- a/src/components/ImportDialog.tsx
+++ b/src/components/ImportDialog.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useCallback } from 'react'
+import { useState, useCallback } from 'react'
 import { useNavigate } from '@tanstack/react-router'
 import { useQueryClient } from '@tanstack/react-query'
 import { api } from '@/lib/api'
@@ -8,22 +8,16 @@ import {
   parseCardJson,
   type ParsedCharacterCard,
 } from '@/lib/importers/tavern-card'
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-} from '@/components/ui/dialog'
+import { FileDropDialog } from '@/components/ui/file-drop-dialog'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
+import { Spinner } from '@/components/ui/async-view'
 import {
   Upload,
   Link as LinkIcon,
   FileArchive,
   FileJson,
   Image,
-  Loader2,
-  AlertCircle,
 } from 'lucide-react'
 
 interface ImportDialogProps {
@@ -39,15 +33,12 @@ type ImportStatus =
 export function ImportDialog({ open, onOpenChange }: ImportDialogProps) {
   const navigate = useNavigate()
   const queryClient = useQueryClient()
-  const fileInputRef = useRef<HTMLInputElement>(null)
-  const [dragOver, setDragOver] = useState(false)
   const [url, setUrl] = useState('')
   const [status, setStatus] = useState<ImportStatus>({ type: 'idle' })
 
   const reset = useCallback(() => {
     setUrl('')
     setStatus({ type: 'idle' })
-    setDragOver(false)
   }, [])
 
   const handleOpenChange = useCallback((v: boolean) => {
@@ -65,7 +56,6 @@ export function ImportDialog({ open, onOpenChange }: ImportDialogProps) {
       description: parsed.card.description.slice(0, 250) || 'Imported from character card',
     })
 
-    // Rebuild raw card JSON for the story page to re-parse
     const cardJson = JSON.stringify({
       data: {
         name: parsed.card.name,
@@ -106,11 +96,9 @@ export function ImportDialog({ open, onOpenChange }: ImportDialogProps) {
     navigate({ to: '/story/$storyId', params: { storyId: newStory.id } })
   }, [navigate, queryClient, handleOpenChange])
 
-  /** Process a single file based on its type */
   const processFile = useCallback(async (file: File) => {
     const name = file.name.toLowerCase()
 
-    // ZIP → story import
     if (name.endsWith('.zip') || file.type === 'application/zip' || file.type === 'application/x-zip-compressed') {
       setStatus({ type: 'processing', message: 'Importing story archive...' })
       try {
@@ -124,7 +112,6 @@ export function ImportDialog({ open, onOpenChange }: ImportDialogProps) {
       return
     }
 
-    // PNG → character card
     if (name.endsWith('.png') || file.type === 'image/png') {
       setStatus({ type: 'processing', message: 'Reading character card image...' })
       try {
@@ -138,7 +125,6 @@ export function ImportDialog({ open, onOpenChange }: ImportDialogProps) {
           setStatus({ type: 'error', message: 'Could not parse the character card data from this PNG.' })
           return
         }
-        // Build image data URL for the import dialog
         const bytes = new Uint8Array(buffer)
         let binary = ''
         for (let j = 0; j < bytes.length; j++) {
@@ -152,7 +138,6 @@ export function ImportDialog({ open, onOpenChange }: ImportDialogProps) {
       return
     }
 
-    // JSON → try character card first, then fail
     if (name.endsWith('.json') || file.type === 'application/json') {
       setStatus({ type: 'processing', message: 'Parsing JSON file...' })
       try {
@@ -172,7 +157,11 @@ export function ImportDialog({ open, onOpenChange }: ImportDialogProps) {
     setStatus({ type: 'error', message: `Unsupported file type. Accepted: .zip, .json, .png` })
   }, [importCharacterCard, navigate, queryClient, handleOpenChange])
 
-  /** Fetch from URL */
+  const handleFiles = useCallback(async (files: File[]) => {
+    const file = files[0]
+    if (file) await processFile(file)
+  }, [processFile])
+
   const handleUrlFetch = useCallback(async () => {
     const trimmed = url.trim()
     if (!trimmed) return
@@ -188,14 +177,12 @@ export function ImportDialog({ open, onOpenChange }: ImportDialogProps) {
       const contentType = res.headers.get('content-type') ?? ''
       const text = await res.text()
 
-      // Try as character card JSON
       const parsed = parseCardJson(text)
       if (parsed) {
         await importCharacterCard(parsed)
         return
       }
 
-      // If content-type suggests JSON but it's not a card
       if (contentType.includes('json') || trimmed.endsWith('.json')) {
         setStatus({ type: 'error', message: 'The fetched JSON is not a recognized character card format (V2/V3).' })
         return
@@ -207,128 +194,90 @@ export function ImportDialog({ open, onOpenChange }: ImportDialogProps) {
     }
   }, [url, importCharacterCard])
 
-  const handleDrop = useCallback(async (e: React.DragEvent) => {
-    e.preventDefault()
-    e.stopPropagation()
-    setDragOver(false)
-    const file = e.dataTransfer.files[0]
-    if (file) await processFile(file)
-  }, [processFile])
-
-  const handleFileInput = useCallback(async (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0]
-    if (file) await processFile(file)
-    e.target.value = ''
-  }, [processFile])
-
   const isProcessing = status.type === 'processing'
 
   return (
-    <Dialog open={open} onOpenChange={handleOpenChange}>
-      <DialogContent className="max-w-md">
-        <DialogHeader>
-          <DialogTitle className="font-display text-lg">Import</DialogTitle>
-        </DialogHeader>
+    <FileDropDialog
+      open={open}
+      onOpenChange={handleOpenChange}
+      title="Import"
+      contentClassName="max-w-md"
+      showCloseButton
+    >
+      <FileDropDialog.Dropzone
+        onFiles={handleFiles}
+        accept=".zip,.json,.png,image/png,application/json,application/zip"
+        disabled={isProcessing}
+        icon={<Upload className="size-6" aria-hidden="true" />}
+        label={
+          isProcessing
+            ? status.message
+            : 'Drag a file here, or click to pick one.'
+        }
+        hint={
+          !isProcessing ? (
+            <span className="inline-flex items-center justify-center gap-3">
+              <span className="inline-flex items-center gap-1">
+                <FileArchive className="size-3" />.zip
+              </span>
+              <span className="inline-flex items-center gap-1">
+                <FileJson className="size-3" />.json
+              </span>
+              <span className="inline-flex items-center gap-1">
+                <Image className="size-3" />.png
+              </span>
+            </span>
+          ) : undefined
+        }
+      >
+        {isProcessing ? (
+          <div className="flex flex-col items-center gap-2 py-3">
+            <Spinner size="md" />
+            <p className="text-xs text-muted-foreground italic">{status.message}</p>
+          </div>
+        ) : undefined}
+      </FileDropDialog.Dropzone>
 
-        <div className="space-y-4 mt-1">
-          {/* Drop zone */}
-          <div
-            onDragOver={(e) => { e.preventDefault(); if (!isProcessing) setDragOver(true) }}
-            onDragLeave={() => setDragOver(false)}
-            onDrop={handleDrop}
-            onClick={() => !isProcessing && fileInputRef.current?.click()}
-            className={`
-              relative flex flex-col items-center justify-center gap-2 rounded-lg border-2 border-dashed
-              px-6 py-8 cursor-pointer transition-all duration-150
-              ${dragOver
-                ? 'border-primary/50 bg-primary/5'
-                : 'border-border/40 hover:border-border/70 hover:bg-muted/30'
-              }
-              ${isProcessing ? 'pointer-events-none opacity-60' : ''}
-            `}
-          >
-            {isProcessing ? (
-              <>
-                <Loader2 className="size-6 text-muted-foreground animate-spin" />
-                <p className="text-sm text-muted-foreground">{status.message}</p>
-              </>
-            ) : (
-              <>
-                <Upload className="size-6 text-muted-foreground" />
-                <div className="text-center">
-                  <p className="text-sm text-muted-foreground">
-                    Drop a file or <span className="text-foreground/70 underline underline-offset-2">browse</span>
-                  </p>
-                  <div className="flex items-center justify-center gap-3 mt-2">
-                    <span className="flex items-center gap-1 text-[0.6875rem] text-muted-foreground">
-                      <FileArchive className="size-3" />.zip
-                    </span>
-                    <span className="flex items-center gap-1 text-[0.6875rem] text-muted-foreground">
-                      <FileJson className="size-3" />.json
-                    </span>
-                    <span className="flex items-center gap-1 text-[0.6875rem] text-muted-foreground">
-                      <Image className="size-3" />.png
-                    </span>
-                  </div>
-                </div>
-              </>
-            )}
-            <input
-              ref={fileInputRef}
-              type="file"
-              accept=".zip,.json,.png,image/png,application/json,application/zip"
-              className="hidden"
-              onChange={handleFileInput}
+      {/* URL input */}
+      <div className="space-y-1.5">
+        <label className="text-[0.6875rem] font-medium text-muted-foreground uppercase tracking-wider">
+          Or import from URL
+        </label>
+        <div className="flex gap-2">
+          <div className="relative flex-1">
+            <LinkIcon className="absolute left-2.5 top-1/2 -translate-y-1/2 size-3.5 text-muted-foreground" />
+            <Input
+              value={url}
+              onChange={(e) => setUrl(e.target.value)}
+              onKeyDown={(e) => { if (e.key === 'Enter') { e.preventDefault(); handleUrlFetch() } }}
+              placeholder="https://..."
+              className="pl-8 text-sm h-9"
+              disabled={isProcessing}
             />
           </div>
-
-          {/* URL input */}
-          <div className="space-y-1.5">
-            <label className="text-[0.6875rem] font-medium text-muted-foreground uppercase tracking-wider">
-              Or import from URL
-            </label>
-            <div className="flex gap-2">
-              <div className="relative flex-1">
-                <LinkIcon className="absolute left-2.5 top-1/2 -translate-y-1/2 size-3.5 text-muted-foreground" />
-                <Input
-                  value={url}
-                  onChange={(e) => setUrl(e.target.value)}
-                  onKeyDown={(e) => { if (e.key === 'Enter') { e.preventDefault(); handleUrlFetch() } }}
-                  placeholder="https://..."
-                  className="pl-8 text-sm h-9"
-                  disabled={isProcessing}
-                />
-              </div>
-              <Button
-                size="sm"
-                variant="outline"
-                className="h-9 px-3"
-                disabled={isProcessing || !url.trim()}
-                onClick={handleUrlFetch}
-              >
-                {isProcessing ? <Loader2 className="size-3.5 animate-spin" /> : 'Fetch'}
-              </Button>
-            </div>
-          </div>
-
-          {/* Error message */}
-          {status.type === 'error' && (
-            <div className="flex items-start gap-2 text-xs text-destructive/80 bg-destructive/5 rounded-md px-3 py-2.5">
-              <AlertCircle className="size-3.5 mt-0.5 shrink-0" />
-              <span>{status.message}</span>
-            </div>
-          )}
-
-          {/* Help text */}
-          <p className="text-[0.6875rem] text-muted-foreground leading-relaxed">
-            <strong className="text-muted-foreground">.zip</strong> — Errata story export
-            {' · '}
-            <strong className="text-muted-foreground">.json</strong> — SillyTavern / TavernAI character card (V2/V3)
-            {' · '}
-            <strong className="text-muted-foreground">.png</strong> — Character card with embedded data
-          </p>
+          <Button
+            size="sm"
+            variant="outline"
+            className="h-9 px-3"
+            disabled={isProcessing || !url.trim()}
+            onClick={handleUrlFetch}
+          >
+            {isProcessing ? <Spinner size="sm" /> : 'Fetch'}
+          </Button>
         </div>
-      </DialogContent>
-    </Dialog>
+      </div>
+
+      <FileDropDialog.Errors>
+        {status.type === 'error' ? status.message : undefined}
+      </FileDropDialog.Errors>
+
+      <p className="text-[0.6875rem] text-muted-foreground leading-relaxed">
+        <strong className="text-muted-foreground">.zip</strong> — Errata story export
+        {' · '}
+        <strong className="text-muted-foreground">.json</strong> — SillyTavern / TavernAI character card (V2/V3)
+        {' · '}
+        <strong className="text-muted-foreground">.png</strong> — Character card with embedded data
+      </p>
+    </FileDropDialog>
   )
 }

--- a/src/components/agents/AgentActivityPanel.tsx
+++ b/src/components/agents/AgentActivityPanel.tsx
@@ -8,6 +8,7 @@ import {
 } from '@/lib/api'
 import { Badge } from '@/components/ui/badge'
 import { ScrollArea } from '@/components/ui/scroll-area'
+import { EmptyState } from '@/components/ui/async-view'
 import {
   Brain,
   ChevronDown,
@@ -166,12 +167,12 @@ function ActivityContent({ storyId }: { storyId: string }) {
               })}
             </div>
           ) : (
-            <div className="flex flex-col items-center justify-center py-16 text-center">
-              <Radio className="size-5 text-muted-foreground mb-3" />
-              <p className="text-xs text-muted-foreground italic max-w-[220px]">
-                No activity yet. Agents run automatically after each generation.
-              </p>
-            </div>
+            <EmptyState
+              icon={<Radio className="size-5" />}
+              title="No activity yet"
+              hint="Agents run automatically after each generation."
+              variant="panel"
+            />
           )}
         </section>
       </div>

--- a/src/components/agents/AgentConfigurePanel.tsx
+++ b/src/components/agents/AgentConfigurePanel.tsx
@@ -6,6 +6,7 @@ import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Textarea } from '@/components/ui/textarea'
 import { ScrollArea } from '@/components/ui/scroll-area'
+import { Spinner, EmptyState } from '@/components/ui/async-view'
 import {
   Dialog,
   DialogContent,
@@ -160,17 +161,16 @@ export function AgentConfigurePanel({ storyId }: AgentConfigurePanelProps) {
 
   if (isLoading) {
     return (
-      <div className="flex flex-col items-center justify-center py-24 text-center">
-        <div className="size-5 rounded-full border-2 border-muted-foreground/15 border-t-muted-foreground/50 animate-spin" />
-        <p className="mt-3 text-[0.6875rem] text-muted-foreground">Loading agents...</p>
+      <div className="flex items-center justify-center py-24">
+        <Spinner />
       </div>
     )
   }
 
   if (!agents || agents.length === 0) {
     return (
-      <div className="flex flex-col items-center justify-center py-24 text-center">
-        <p className="text-xs text-muted-foreground italic">No agents registered</p>
+      <div className="flex items-center justify-center py-24">
+        <EmptyState title="No agents registered" />
       </div>
     )
   }
@@ -518,17 +518,16 @@ function AgentBlockEditor({ storyId, agentName, agents, onBack }: AgentBlockEdit
 
   if (isLoading) {
     return (
-      <div className="flex flex-col items-center justify-center py-24 text-center">
-        <div className="size-5 rounded-full border-2 border-muted-foreground/15 border-t-muted-foreground/50 animate-spin" />
-        <p className="mt-3 text-[0.6875rem] text-muted-foreground">Loading agent blocks...</p>
+      <div className="flex items-center justify-center py-24">
+        <Spinner />
       </div>
     )
   }
 
   if (!data) {
     return (
-      <div className="flex flex-col items-center justify-center py-24 text-center">
-        <p className="text-xs text-muted-foreground italic">Failed to load agent blocks</p>
+      <div className="flex items-center justify-center py-24">
+        <EmptyState title="Could not load agent blocks" />
       </div>
     )
   }
@@ -1013,13 +1012,12 @@ function AgentBlockEditor({ storyId, agentName, agents, onBack }: AgentBlockEdit
           </DialogHeader>
 
           {previewLoading ? (
-            <div className="flex flex-col items-center justify-center py-20 text-center">
-              <div className="size-5 rounded-full border-2 border-muted-foreground/15 border-t-muted-foreground/50 animate-spin" />
-              <p className="mt-3 text-[0.6875rem] text-muted-foreground">Compiling context...</p>
+            <div className="flex items-center justify-center py-20">
+              <Spinner label="Compiling context" />
             </div>
           ) : previewData?.messages.length === 0 ? (
-            <div className="flex flex-col items-center justify-center py-20 text-center">
-              <p className="text-xs text-muted-foreground italic">No messages in context</p>
+            <div className="flex items-center justify-center py-20">
+              <EmptyState title="No messages in context" />
             </div>
           ) : previewData ? (
             <BlockContentView

--- a/src/components/agents/AgentConfigurePanel.tsx
+++ b/src/components/agents/AgentConfigurePanel.tsx
@@ -159,6 +159,11 @@ export function AgentConfigurePanel({ storyId }: AgentConfigurePanelProps) {
     queryFn: () => api.agentBlocks.list(),
   })
 
+  const { data: story } = useQuery({
+    queryKey: ['story', storyId],
+    queryFn: () => api.stories.get(storyId),
+  })
+
   if (isLoading) {
     return (
       <div className="flex items-center justify-center py-24">
@@ -186,7 +191,11 @@ export function AgentConfigurePanel({ storyId }: AgentConfigurePanelProps) {
     )
   }
 
-  const groups = groupAgents(agents)
+  const generationMode = story?.settings.generationMode ?? 'standard'
+  const visibleAgents = generationMode === 'prewriter'
+    ? agents
+    : agents.filter((a) => a.agentName !== 'generation.prewriter')
+  const groups = groupAgents(visibleAgents)
 
   return (
     <div className="flex h-full min-h-0 flex-col">

--- a/src/components/blocks/BlockContentView.tsx
+++ b/src/components/blocks/BlockContentView.tsx
@@ -3,6 +3,7 @@ import { ScrollArea } from '@/components/ui/scroll-area'
 import { Badge } from '@/components/ui/badge'
 import { cn } from '@/lib/utils'
 import { componentId } from '@/lib/dom-ids'
+import { EmptyHint } from '@/components/ui/prose-text'
 
 interface BlockContentViewProps {
   messages: Array<{ role: string; content: string }>
@@ -70,7 +71,7 @@ export function BlockContentView({ messages, blocks, className }: BlockContentVi
   if (segments.length === 0) {
     return (
       <div className={cn('flex items-center justify-center py-16', className)}>
-        <p className="text-xs text-muted-foreground italic">No blocks in context</p>
+        <EmptyHint>No blocks in context</EmptyHint>
       </div>
     )
   }

--- a/src/components/blocks/BlockEditorPanel.tsx
+++ b/src/components/blocks/BlockEditorPanel.tsx
@@ -19,6 +19,7 @@ import {
 import { BlockCreateDialog } from './BlockCreateDialog'
 import { BlockPreviewDialog } from './BlockPreviewDialog'
 import { ScriptBlockEditor, FragmentReference } from './ScriptBlockEditor'
+import { Spinner, EmptyState } from '@/components/ui/async-view'
 import { cn } from '@/lib/utils'
 import { useHelp } from '@/hooks/use-help'
 import { componentId } from '@/lib/dom-ids'
@@ -271,17 +272,16 @@ export function BlockEditorPanel({ storyId }: BlockEditorPanelProps) {
 
   if (isLoading) {
     return (
-      <div className="flex flex-col items-center justify-center py-24 text-center">
-        <div className="size-5 rounded-full border-2 border-muted-foreground/15 border-t-muted-foreground/50 animate-spin" />
-        <p className="mt-3 text-[0.6875rem] text-muted-foreground">Loading blocks...</p>
+      <div className="flex items-center justify-center py-24">
+        <Spinner />
       </div>
     )
   }
 
   if (!data) {
     return (
-      <div className="flex flex-col items-center justify-center py-24 text-center">
-        <p className="text-xs text-muted-foreground italic">Failed to load blocks</p>
+      <div className="flex items-center justify-center py-24">
+        <EmptyState title="Could not load blocks" />
       </div>
     )
   }

--- a/src/components/blocks/BlockPreviewDialog.tsx
+++ b/src/components/blocks/BlockPreviewDialog.tsx
@@ -7,6 +7,7 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog'
 import { Badge } from '@/components/ui/badge'
+import { Spinner, EmptyState } from '@/components/ui/async-view'
 import { BlockContentView } from './BlockContentView'
 
 interface BlockPreviewDialogProps {
@@ -37,13 +38,12 @@ export function BlockPreviewDialog({ storyId, open, onOpenChange }: BlockPreview
         </DialogHeader>
 
         {isLoading ? (
-          <div className="flex flex-col items-center justify-center py-20 text-center">
-            <div className="size-5 rounded-full border-2 border-muted-foreground/15 border-t-muted-foreground/50 animate-spin" />
-            <p className="mt-3 text-[0.6875rem] text-muted-foreground">Compiling context...</p>
+          <div className="flex items-center justify-center py-20">
+            <Spinner label="Compiling context" />
           </div>
         ) : data?.messages.length === 0 ? (
-          <div className="flex flex-col items-center justify-center py-20 text-center">
-            <p className="text-xs text-muted-foreground italic">No messages in context</p>
+          <div className="flex items-center justify-center py-20">
+            <EmptyState title="No messages in context" />
           </div>
         ) : data ? (
           <BlockContentView

--- a/src/components/character-chat/CharacterChatView.tsx
+++ b/src/components/character-chat/CharacterChatView.tsx
@@ -6,6 +6,7 @@ import { Button } from '@/components/ui/button'
 import { Textarea } from '@/components/ui/textarea'
 import { ScrollArea } from '@/components/ui/scroll-area'
 import { Send, Loader2 } from 'lucide-react'
+import { Caption, EmptyHint } from '@/components/ui/prose-text'
 import {
   AssistantMessageView,
   type AssistantMessage,
@@ -281,9 +282,9 @@ export function CharacterChatView({ storyId, initialCharacterId, onClose }: Char
                 <h3 className="font-display text-xl tracking-tight mb-1">
                   {selectedCharacter.name}
                 </h3>
-                <p className="text-xs text-muted-foreground italic max-w-[280px]">
+                <Caption className="italic max-w-[280px]">
                   {selectedCharacter.description}
-                </p>
+                </Caption>
               </div>
               <p className="text-[0.6875rem] text-muted-foreground max-w-[240px] leading-relaxed">
                 Start a conversation. The character will respond in their voice, knowing only the story events up to your selected point.
@@ -294,18 +295,18 @@ export function CharacterChatView({ storyId, initialCharacterId, onClose }: Char
           {/* No character selected */}
           {messages.length === 0 && !selectedCharacter && characters.length > 0 && (
             <div className="flex flex-col items-center justify-center py-16 text-center">
-              <p className="text-xs text-muted-foreground italic">
+              <EmptyHint>
                 Select a character to begin.
-              </p>
+              </EmptyHint>
             </div>
           )}
 
           {/* No characters in story */}
           {characters.length === 0 && (
             <div className="flex flex-col items-center justify-center py-16 text-center">
-              <p className="text-xs text-muted-foreground italic max-w-[240px]">
+              <EmptyHint className="max-w-[240px]">
                 Create character fragments in your story first, then return here to chat with them.
-              </p>
+              </EmptyHint>
             </div>
           )}
 

--- a/src/components/character-chat/ConversationList.tsx
+++ b/src/components/character-chat/ConversationList.tsx
@@ -2,7 +2,15 @@ import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { api, type Fragment } from '@/lib/api'
 import type { CharacterChatConversationSummary, PersonaMode } from '@/lib/api/types'
 import { Button } from '@/components/ui/button'
-import { ScrollArea } from '@/components/ui/scroll-area'
+import { Spinner, EmptyState } from '@/components/ui/async-view'
+import {
+  Panel,
+  PanelActions,
+  PanelBody,
+  PanelHeader,
+  PanelHeaderText,
+  PanelTitle,
+} from '@/components/ui/panel'
 import { X, Plus, Trash2, MessageSquare, User, Users, Sparkles } from 'lucide-react'
 import { resolveFragmentVisual } from '@/lib/fragment-visuals'
 
@@ -80,14 +88,15 @@ export function ConversationList({
   }
 
   return (
-    <div
-      className="absolute inset-0 z-20 bg-background/95 backdrop-blur-sm flex flex-col"
+    <Panel
+      className="absolute inset-0 z-20 bg-background/95 backdrop-blur-sm"
       data-component-id="character-chat-conversation-list"
     >
-      {/* Header */}
-      <div className="flex items-center justify-between px-4 py-3 border-b border-border/30">
-        <h3 className="font-display text-lg tracking-tight">Conversations</h3>
-        <div className="flex items-center gap-2">
+      <PanelHeader className="px-4 py-3">
+        <PanelHeaderText>
+          <PanelTitle>Conversations</PanelTitle>
+        </PanelHeaderText>
+        <PanelActions className="gap-2">
           <Button
             size="sm"
             variant="outline"
@@ -105,23 +114,22 @@ export function ConversationList({
           >
             <X className="size-3.5" />
           </Button>
-        </div>
-      </div>
+        </PanelActions>
+      </PanelHeader>
 
-      {/* List */}
-      <ScrollArea className="flex-1 min-h-0">
-        <div className="p-3 space-y-1">
+      <PanelBody className="p-3 gap-1">
           {isLoading && (
-            <p className="text-xs text-muted-foreground italic text-center py-8">Loading...</p>
+            <div className="flex items-center justify-center py-8">
+              <Spinner size="sm" />
+            </div>
           )}
 
           {!isLoading && (!conversations || conversations.length === 0) && (
-            <div className="flex flex-col items-center justify-center py-12 text-center gap-3">
-              <MessageSquare className="size-8 text-muted-foreground" />
-              <p className="text-xs text-muted-foreground italic max-w-[200px]">
-                No conversations yet. Start one to talk with your characters.
-              </p>
-            </div>
+            <EmptyState
+              icon={<MessageSquare className="size-5" />}
+              title="No conversations yet"
+              hint="Start one to talk with your characters."
+            />
           )}
 
           {[...grouped.entries()].map(([charId, convs]) => {
@@ -201,8 +209,7 @@ export function ConversationList({
               </div>
             )
           })}
-        </div>
-      </ScrollArea>
-    </div>
+      </PanelBody>
+    </Panel>
   )
 }

--- a/src/components/fragments/CharacterCardImportDialog.tsx
+++ b/src/components/fragments/CharacterCardImportDialog.tsx
@@ -12,11 +12,7 @@ import { Badge } from '@/components/ui/badge'
 import { Checkbox } from '@/components/ui/checkbox'
 import { Input } from '@/components/ui/input'
 import { ScrollArea } from '@/components/ui/scroll-area'
-import {
-  Dialog,
-  DialogContent,
-  DialogFooter,
-} from '@/components/ui/dialog'
+import { FileDropDialog } from '@/components/ui/file-drop-dialog'
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -33,7 +29,6 @@ import {
   Pin,
   ChevronDown,
   Loader2,
-  AlertCircle,
   Link as LinkIcon,
 } from 'lucide-react'
 
@@ -79,13 +74,11 @@ export function CharacterCardImportDialog({
   onImported,
 }: CharacterCardImportDialogProps) {
   const queryClient = useQueryClient()
-  const fileInputRef = useRef<HTMLInputElement>(null)
   const urlInputRef = useRef<HTMLInputElement>(null)
 
   const [cardData, setCardData] = useState<ParsedCharacterCard | null>(null)
   const [itemStates, setItemStates] = useState<Map<string, ItemState>>(new Map())
   const [parseError, setParseError] = useState<string | null>(null)
-  const [dragOver, setDragOver] = useState(false)
   const [urlFetching, setUrlFetching] = useState(false)
   const [urlError, setUrlError] = useState<string | null>(null)
 
@@ -95,7 +88,6 @@ export function CharacterCardImportDialog({
       setCardData(null)
       setItemStates(new Map())
       setParseError(null)
-      setDragOver(false)
       setUrlFetching(false)
       setUrlError(null)
       return
@@ -116,28 +108,8 @@ export function CharacterCardImportDialog({
     setItemStates(states)
   }, [])
 
-  const handleFileInput = useCallback(async (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0]
-    if (!file) return
-    try {
-      const text = await file.text()
-      const parsed = parseCardJson(text)
-      if (parsed) {
-        loadCard(parsed)
-      } else {
-        setParseError('This file does not contain a recognized character card format.')
-      }
-    } catch {
-      setParseError('Could not read file.')
-    }
-    e.target.value = ''
-  }, [loadCard])
-
-  const handleDrop = useCallback(async (e: React.DragEvent) => {
-    e.preventDefault()
-    e.stopPropagation()
-    setDragOver(false)
-    const file = e.dataTransfer.files?.[0]
+  const handleFiles = useCallback(async (files: File[]) => {
+    const file = files[0]
     if (!file) return
     try {
       const text = await file.text()
@@ -238,17 +210,14 @@ export function CharacterCardImportDialog({
           meta: item.meta,
         })
 
-        // Set sticky if needed (via separate API call)
         if (item.sticky) {
           await api.fragments.toggleSticky(storyId, fragment.id, true)
         }
 
-        // Set placement if system
         if (item.placement === 'system') {
           await api.fragments.setPlacement(storyId, fragment.id, 'system')
         }
 
-        // Add prose to chain
         if (item.finalType === 'prose') {
           await api.proseChain.addSection(storyId, fragment.id)
         }
@@ -285,280 +254,191 @@ export function CharacterCardImportDialog({
 
   const hasCard = cardData !== null
 
+  const description = hasCard ? (
+    <span className="flex items-center gap-2">
+      <span className="font-medium text-foreground/70">{cardData.card.name}</span>
+      {cardData.card.spec && (
+        <Badge variant="outline" className="text-[0.5625rem] h-4 px-1.5 border-border/40 text-muted-foreground">
+          {cardData.card.spec}
+        </Badge>
+      )}
+      {cardData.card.creator && (
+        <span className="text-muted-foreground">by {cardData.card.creator}</span>
+      )}
+      <span className="text-muted-foreground ml-auto tabular-nums">
+        {totalCount} {totalCount === 1 ? 'entry' : 'entries'}
+      </span>
+    </span>
+  ) : (
+    'JSON character card with optional lorebook entries'
+  )
+
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent
-        showCloseButton={false}
-        className={`max-h-[85vh] flex flex-col overflow-hidden p-0 gap-0 border-border/60 bg-card transition-[max-width] duration-300 ${
-          hasCard ? 'max-w-2xl' : 'max-w-[480px]'
-        }`}
-      >
-        {/* ── Header ── */}
-        <div className="px-6 pt-6 pb-4">
-          <p className="font-display text-xl tracking-tight">
-            {hasCard ? 'Import Character Card' : 'Import Character Card'}
-          </p>
-          <p className="text-xs text-muted-foreground mt-1">
-            {hasCard ? (
-              <span className="flex items-center gap-2">
-                <span className="font-medium text-foreground/70">{cardData.card.name}</span>
-                {cardData.card.spec && (
-                  <Badge variant="outline" className="text-[0.5625rem] h-4 px-1.5 border-border/40 text-muted-foreground">
-                    {cardData.card.spec}
-                  </Badge>
-                )}
-                {cardData.card.creator && (
-                  <span className="text-muted-foreground">by {cardData.card.creator}</span>
-                )}
-                <span className="text-muted-foreground ml-auto tabular-nums">
-                  {totalCount} {totalCount === 1 ? 'entry' : 'entries'}
-                </span>
-              </span>
-            ) : (
-              'JSON character card with optional lorebook entries'
-            )}
-          </p>
-        </div>
+    <FileDropDialog
+      open={open}
+      onOpenChange={onOpenChange}
+      title="Import Character Card"
+      description={description}
+      contentClassName={`transition-[max-width] duration-300 ${hasCard ? 'max-w-2xl' : 'max-w-[480px]'}`}
+    >
+      {!hasCard && (
+        <>
+          <FileDropDialog.Dropzone
+            onFiles={handleFiles}
+            accept=".json,application/json"
+            label="Drop character card JSON"
+            hint="V2 or V3 character card .json files"
+            icon={<BookOpen className="size-7" aria-hidden="true" />}
+          />
 
-        <div className="flex-1 overflow-hidden min-h-0 px-5 pb-4 flex flex-col gap-3">
-          {/* ── Empty state: drop zone + URL input ── */}
-          {!hasCard && (
-            <>
-              <div
-                className={`relative group rounded-xl overflow-hidden cursor-pointer transition-all duration-300 ${
-                  dragOver ? 'scale-[0.98]' : 'hover:scale-[0.995]'
-                }`}
-                onDragOver={(e) => { e.preventDefault(); setDragOver(true) }}
-                onDragLeave={() => setDragOver(false)}
-                onDrop={handleDrop}
-                onClick={() => fileInputRef.current?.click()}
-              >
-                <svg className="absolute inset-0 w-full h-full pointer-events-none" preserveAspectRatio="none">
-                  <rect
-                    x="1" y="1"
-                    width="calc(100% - 2px)" height="calc(100% - 2px)"
-                    rx="11" ry="11"
-                    fill="none"
-                    className={`transition-all duration-300 ${
-                      dragOver ? 'stroke-primary/50' : 'stroke-border/60 group-hover:stroke-border'
-                    }`}
-                    strokeWidth="1.5"
-                    strokeDasharray="6 6"
-                    style={{ animation: 'tavern-dropzone-dash 1.5s linear infinite' }}
-                  />
-                </svg>
+          <div className="flex items-center gap-2">
+            <div className="h-px flex-1 bg-border/30" />
+            <span className="text-[0.625rem] text-muted-foreground uppercase tracking-wider">or paste URL</span>
+            <div className="h-px flex-1 bg-border/30" />
+          </div>
 
-                <div className={`relative flex flex-col items-center justify-center py-12 px-8 transition-colors duration-300 ${
-                  dragOver ? 'bg-primary/[0.04]' : 'bg-muted/30'
-                }`}>
-                  <div className={`relative mb-4 transition-all duration-300 ${
-                    dragOver ? 'scale-110' : 'group-hover:scale-105'
-                  }`}>
-                    <div className="w-14 h-16 rounded-lg bg-gradient-to-b from-muted-foreground/[0.07] to-muted-foreground/[0.03] flex items-center justify-center overflow-hidden">
-                      <BookOpen className={`size-7 transition-colors duration-300 ${
-                        dragOver ? 'text-primary/40' : 'text-muted-foreground group-hover:text-muted-foreground'
-                      }`} />
-                    </div>
-                    {dragOver && (
-                      <div
-                        className="absolute -inset-3 rounded-2xl bg-primary/10 blur-lg"
-                        style={{ animation: 'tavern-dropzone-glow 2s ease-in-out infinite' }}
-                      />
-                    )}
-                  </div>
-
-                  <p className={`font-display text-base tracking-tight transition-colors duration-200 ${
-                    dragOver ? 'text-primary' : 'text-foreground/70 group-hover:text-foreground/80'
-                  }`}>
-                    Drop character card JSON
-                  </p>
-                  <p className="text-[0.6875rem] text-muted-foreground mt-1.5">
-                    V2 or V3 character card .json files
-                  </p>
-                </div>
-              </div>
-
-              {/* URL input */}
-              <div className="flex items-center gap-2">
-                <div className="h-px flex-1 bg-border/30" />
-                <span className="text-[0.625rem] text-muted-foreground uppercase tracking-wider">or paste URL</span>
-                <div className="h-px flex-1 bg-border/30" />
-              </div>
-
-              <div className="flex gap-2">
-                <div className="relative flex-1">
-                  <LinkIcon className="absolute left-2.5 top-1/2 -translate-y-1/2 size-3.5 text-muted-foreground" />
-                  <Input
-                    ref={urlInputRef}
-                    placeholder="https://example.com/card.json"
-                    className="pl-8 h-9 text-sm bg-muted/20"
-                    onKeyDown={handleUrlKeyDown}
-                    disabled={urlFetching}
-                  />
-                </div>
-                <Button
-                  variant="outline"
-                  size="sm"
-                  onClick={handleUrlFetch}
-                  disabled={urlFetching}
-                  className="gap-1.5 shrink-0"
-                >
-                  {urlFetching ? (
-                    <Loader2 className="size-3.5 animate-spin" />
-                  ) : (
-                    <Globe className="size-3.5" />
-                  )}
-                  Fetch
-                </Button>
-              </div>
-
-              <input
-                ref={fileInputRef}
-                type="file"
-                accept=".json,application/json"
-                className="hidden"
-                onChange={handleFileInput}
+          <div className="flex gap-2">
+            <div className="relative flex-1">
+              <LinkIcon className="absolute left-2.5 top-1/2 -translate-y-1/2 size-3.5 text-muted-foreground" />
+              <Input
+                ref={urlInputRef}
+                placeholder="https://example.com/card.json"
+                className="pl-8 h-9 text-sm bg-muted/20"
+                onKeyDown={handleUrlKeyDown}
+                disabled={urlFetching}
               />
-            </>
-          )}
-
-          {/* ── Card loaded: item list ── */}
-          {hasCard && (
-            <>
-              {/* Optional image thumbnail */}
-              {imageDataUrl && (
-                <div className="flex items-center gap-3 mb-1">
-                  <img
-                    src={imageDataUrl}
-                    alt=""
-                    className="size-12 rounded-lg object-cover object-top border border-border/40"
-                  />
-                  <div className="min-w-0">
-                    <p className="text-sm font-medium truncate">{cardData.card.name}</p>
-                    {cardData.card.description && (
-                      <p className="text-[0.6875rem] text-muted-foreground line-clamp-1">
-                        {cardData.card.description}
-                      </p>
-                    )}
-                  </div>
-                </div>
-              )}
-
-              {/* Select controls */}
-              <div className="flex items-center gap-3 text-[0.6875rem]">
-                <button
-                  onClick={selectAll}
-                  className="text-primary/60 hover:text-primary transition-colors"
-                >
-                  Select all
-                </button>
-                <span className="text-border/60">/</span>
-                <button
-                  onClick={deselectAll}
-                  className="text-muted-foreground hover:text-muted-foreground transition-colors"
-                >
-                  Deselect all
-                </button>
-                <span className="ml-auto text-muted-foreground tabular-nums">
-                  {selectedCount} selected
-                </span>
-              </div>
-
-              {/* Grouped item list */}
-              <ScrollArea className="flex-1 min-h-0 -mx-1 px-1">
-                <div className="space-y-3 pb-1">
-                  {SOURCE_GROUPS.map((group) => {
-                    const groupItems = cardData.items.filter((item) =>
-                      (group.sources as readonly string[]).includes(item.source),
-                    )
-                    if (groupItems.length === 0) return null
-
-                    return (
-                      <div key={group.key}>
-                        <div className="flex items-center gap-2 mb-1.5">
-                          <span className="text-[0.625rem] uppercase tracking-wider text-muted-foreground font-medium">
-                            {group.label}
-                          </span>
-                          <div className="h-px flex-1 bg-border/20" />
-                          {group.key === 'lorebook' && (
-                            <span className="text-[0.625rem] text-muted-foreground tabular-nums">
-                              {groupItems.length}
-                            </span>
-                          )}
-                        </div>
-                        <div className="space-y-1">
-                          {groupItems.map((item) => (
-                            <ItemRow
-                              key={item.key}
-                              item={item}
-                              state={itemStates.get(item.key) ?? { enabled: false, typeOverride: null }}
-                              onToggle={() => toggleItem(item.key)}
-                              onTypeChange={(type) => setItemType(item.key, type)}
-                            />
-                          ))}
-                        </div>
-                      </div>
-                    )
-                  })}
-                </div>
-              </ScrollArea>
-            </>
-          )}
-
-          {/* Error messages */}
-          {(parseError || urlError) && (
-            <div className="flex items-start gap-2 text-xs text-destructive/80 bg-destructive/5 rounded-lg px-3 py-2.5">
-              <AlertCircle className="size-3.5 mt-0.5 shrink-0" />
-              <span>{parseError || urlError}</span>
             </div>
-          )}
-
-          {importMutation.isError && (
-            <div className="flex items-start gap-2 text-xs text-destructive/80 bg-destructive/5 rounded-lg px-3 py-2.5">
-              <AlertCircle className="size-3.5 mt-0.5 shrink-0" />
-              <span>Import failed. Please try again.</span>
-            </div>
-          )}
-        </div>
-
-        {/* ── Ornamental divider ── */}
-        <div className="px-6">
-          <div className="h-px bg-gradient-to-r from-transparent via-border/60 to-transparent" />
-        </div>
-
-        {/* ── Footer ── */}
-        <DialogFooter className="px-5 py-3.5 flex-row items-center">
-          {hasCard && (
-            <span className="text-[0.6875rem] text-muted-foreground mr-auto tabular-nums">
-              {selectedCount} of {totalCount} selected
-            </span>
-          )}
-          <Button variant="ghost" size="sm" className="text-muted-foreground" onClick={() => onOpenChange(false)}>
-            Cancel
-          </Button>
-          {hasCard && (
             <Button
+              variant="outline"
               size="sm"
-              disabled={selectedCount === 0 || importMutation.isPending}
-              onClick={handleImport}
-              className="gap-1.5"
+              onClick={handleUrlFetch}
+              disabled={urlFetching}
+              className="gap-1.5 shrink-0"
             >
-              {importMutation.isPending ? (
-                <>
-                  <Loader2 className="size-3.5 animate-spin" />
-                  Importing…
-                </>
+              {urlFetching ? (
+                <Loader2 className="size-3.5 animate-spin" />
               ) : (
-                <>
-                  <Check className="size-3.5" />
-                  Import {selectedCount} {selectedCount === 1 ? 'Entry' : 'Entries'}
-                </>
+                <Globe className="size-3.5" />
               )}
+              Fetch
             </Button>
+          </div>
+        </>
+      )}
+
+      {hasCard && (
+        <FileDropDialog.Preview>
+          {imageDataUrl && (
+            <div className="flex items-center gap-3 mb-1">
+              <img
+                src={imageDataUrl}
+                alt=""
+                className="size-12 rounded-lg object-cover object-top border border-border/40"
+              />
+              <div className="min-w-0">
+                <p className="text-sm font-medium truncate">{cardData.card.name}</p>
+                {cardData.card.description && (
+                  <p className="text-[0.6875rem] text-muted-foreground line-clamp-1">
+                    {cardData.card.description}
+                  </p>
+                )}
+              </div>
+            </div>
           )}
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
+
+          <div className="flex items-center gap-3 text-[0.6875rem]">
+            <button
+              onClick={selectAll}
+              className="text-primary/60 hover:text-primary transition-colors"
+            >
+              Select all
+            </button>
+            <span className="text-border/60">/</span>
+            <button
+              onClick={deselectAll}
+              className="text-muted-foreground hover:text-muted-foreground transition-colors"
+            >
+              Deselect all
+            </button>
+            <span className="ml-auto text-muted-foreground tabular-nums">
+              {selectedCount} selected
+            </span>
+          </div>
+
+          <ScrollArea className="flex-1 min-h-0 -mx-1 px-1">
+            <div className="space-y-3 pb-1">
+              {SOURCE_GROUPS.map((group) => {
+                const groupItems = cardData.items.filter((item) =>
+                  (group.sources as readonly string[]).includes(item.source),
+                )
+                if (groupItems.length === 0) return null
+
+                return (
+                  <div key={group.key}>
+                    <div className="flex items-center gap-2 mb-1.5">
+                      <span className="text-[0.625rem] uppercase tracking-wider text-muted-foreground font-medium">
+                        {group.label}
+                      </span>
+                      <div className="h-px flex-1 bg-border/20" />
+                      {group.key === 'lorebook' && (
+                        <span className="text-[0.625rem] text-muted-foreground tabular-nums">
+                          {groupItems.length}
+                        </span>
+                      )}
+                    </div>
+                    <div className="space-y-1">
+                      {groupItems.map((item) => (
+                        <ItemRow
+                          key={item.key}
+                          item={item}
+                          state={itemStates.get(item.key) ?? { enabled: false, typeOverride: null }}
+                          onToggle={() => toggleItem(item.key)}
+                          onTypeChange={(type) => setItemType(item.key, type)}
+                        />
+                      ))}
+                    </div>
+                  </div>
+                )
+              })}
+            </div>
+          </ScrollArea>
+        </FileDropDialog.Preview>
+      )}
+
+      <FileDropDialog.Errors>{parseError || urlError}</FileDropDialog.Errors>
+
+      {importMutation.isError && (
+        <FileDropDialog.Errors>Import failed. Please try again.</FileDropDialog.Errors>
+      )}
+
+      <FileDropDialog.Actions
+        meta={hasCard ? `${selectedCount} of ${totalCount} selected` : undefined}
+      >
+        <Button variant="ghost" size="sm" className="text-muted-foreground" onClick={() => onOpenChange(false)}>
+          Cancel
+        </Button>
+        {hasCard && (
+          <Button
+            size="sm"
+            disabled={selectedCount === 0 || importMutation.isPending}
+            onClick={handleImport}
+            className="gap-1.5"
+          >
+            {importMutation.isPending ? (
+              <>
+                <Loader2 className="size-3.5 animate-spin" />
+                Importing…
+              </>
+            ) : (
+              <>
+                <Check className="size-3.5" />
+                Import {selectedCount} {selectedCount === 1 ? 'Entry' : 'Entries'}
+              </>
+            )}
+          </Button>
+        )}
+      </FileDropDialog.Actions>
+    </FileDropDialog>
   )
 }
 
@@ -588,7 +468,6 @@ function ItemRow({
       }`}
       onClick={onToggle}
     >
-      {/* Checkbox */}
       <Checkbox
         checked={state.enabled}
         onClick={(e) => e.stopPropagation()}
@@ -596,7 +475,6 @@ function ItemRow({
         className="mt-0.5 shrink-0"
       />
 
-      {/* Content */}
       <div className="min-w-0 flex-1">
         <div className="flex items-center gap-2 mb-0.5">
           <span className="text-sm font-medium truncate leading-tight">
@@ -607,12 +485,10 @@ function ItemRow({
           )}
         </div>
 
-        {/* Content preview */}
         <p className="text-[0.6875rem] text-muted-foreground line-clamp-1 leading-relaxed">
           {item.content.slice(0, 120)}
         </p>
 
-        {/* Tags */}
         {item.tags.length > 0 && (
           <div className="flex items-center gap-1 mt-1 flex-wrap">
             {item.tags.slice(0, 4).map((tag) => (
@@ -632,7 +508,6 @@ function ItemRow({
         )}
       </div>
 
-      {/* Type badge / dropdown */}
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
           <button

--- a/src/components/fragments/ContextOrderPanel.tsx
+++ b/src/components/fragments/ContextOrderPanel.tsx
@@ -5,6 +5,7 @@ import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { ScrollArea } from '@/components/ui/scroll-area'
 import { GripVertical, Monitor, User } from 'lucide-react'
+import { EmptyHint } from '@/components/ui/prose-text'
 import { cn } from '@/lib/utils'
 
 interface ContextOrderPanelProps {
@@ -107,9 +108,9 @@ export function ContextOrderPanel({ storyId, story }: ContextOrderPanelProps) {
   if (stickyFragments.length === 0) {
     return (
       <div className="p-6 text-center">
-        <p className="text-sm text-muted-foreground italic">
+        <EmptyHint size="sm">
           No pinned fragments. Pin fragments from the Characters, Guidelines, or Knowledge panels.
-        </p>
+        </EmptyHint>
       </div>
     )
   }

--- a/src/components/fragments/FragmentEditor.tsx
+++ b/src/components/fragments/FragmentEditor.tsx
@@ -13,6 +13,7 @@ import type { FrozenSection } from '@/lib/api/types'
 import { RefinementPanel } from '@/components/refinement/RefinementPanel'
 import { copyFragmentToClipboard } from '@/lib/fragment-clipboard'
 import { CropDialog } from '@/components/fragments/CropDialog'
+import { Hint, EmptyHint, MetaLabel } from '@/components/ui/prose-text'
 
 export interface FragmentPrefill {
   name: string
@@ -743,9 +744,9 @@ export function FragmentEditor({
                 >
                   <ImagePlus className="size-8 text-muted-foreground" />
                   <div className="text-center">
-                    <p className="text-sm text-muted-foreground">
+                    <Hint size="sm">
                       {isEditing ? 'Drop an image here or click to upload' : 'No image set'}
-                    </p>
+                    </Hint>
                     <p className="text-[0.6875rem] text-muted-foreground mt-1">PNG, JPG, SVG, or paste a URL</p>
                   </div>
                   {isEditing && (
@@ -899,7 +900,7 @@ export function FragmentEditor({
                     <span className="text-[0.625rem] text-muted-foreground">Current v{fragment.version ?? 1}</span>
                   </div>
                   {versions.length === 0 ? (
-                    <p className="text-xs text-muted-foreground">No previous versions yet.</p>
+                    <Hint>No previous versions yet.</Hint>
                   ) : (
                     <div className="space-y-1.5 max-h-36 overflow-auto pr-1">
                       {versions.map((v: FragmentVersion) => (
@@ -980,10 +981,10 @@ export function FragmentEditor({
               </>
             ) : (
               <>
-                <span className="text-xs text-muted-foreground transition-opacity">
+                <MetaLabel className="transition-opacity">
                   {saveStatus === 'saving' && 'Saving...'}
                   {saveStatus === 'saved' && 'Saved'}
-                </span>
+                </MetaLabel>
                 <div className="flex-1" />
                 <Button type="button" size="sm" variant="ghost" onClick={handleClose}>
                   Close
@@ -1184,7 +1185,7 @@ function VisualRefsSection({ storyId, fragmentId }: { storyId: string; fragmentI
       )}
 
       {visualRefs.length === 0 && unlinkedMedia.length === 0 && (
-        <p className="text-xs text-muted-foreground italic mb-2">No image or icon linked</p>
+        <EmptyHint className="mb-2">No image or icon linked</EmptyHint>
       )}
 
       {/* Available media — click to instantly link */}
@@ -1319,7 +1320,7 @@ function TagsSection({ storyId, fragmentId }: { storyId: string; fragmentId: str
           </Badge>
         ))}
         {(!data?.tags || data.tags.length === 0) && (
-          <span className="text-xs text-muted-foreground italic">No tags</span>
+          <EmptyHint asChild><span>No tags</span></EmptyHint>
         )}
       </div>
       <div className="flex gap-1.5">
@@ -1400,7 +1401,7 @@ function RefsSection({ storyId, fragmentId }: { storyId: string; fragmentId: str
           </Badge>
         ))}
         {(!data?.refs || data.refs.length === 0) && (
-          <span className="text-xs text-muted-foreground italic">No refs</span>
+          <EmptyHint asChild><span>No refs</span></EmptyHint>
         )}
       </div>
       {data?.backRefs && data.backRefs.length > 0 && (

--- a/src/components/fragments/FragmentExportPanel.tsx
+++ b/src/components/fragments/FragmentExportPanel.tsx
@@ -5,8 +5,17 @@ import { resolveFragmentVisual, generateBubbles, hexagonPoints, diamondPoints, t
 import { serializeFragment, serializeBundle, downloadExportFile } from '@/lib/fragment-clipboard'
 import { Button } from '@/components/ui/button'
 import { Checkbox } from '@/components/ui/checkbox'
-import { ScrollArea } from '@/components/ui/scroll-area'
 import { Badge } from '@/components/ui/badge'
+import { EmptyHint, Hint } from '@/components/ui/prose-text'
+import {
+  Panel,
+  PanelActions,
+  PanelBody,
+  PanelFooter,
+  PanelHeader,
+  PanelHeaderText,
+  PanelTitle,
+} from '@/components/ui/panel'
 import {
   X,
   Download,
@@ -187,25 +196,26 @@ export function FragmentExportPanel({ storyId, storyName, onClose }: FragmentExp
   const allSelected = allExportable.length > 0 && allExportable.every((f) => selected.has(f.id))
 
   return (
-    <div className="flex flex-col h-full">
-      {/* Header */}
-      <div className="flex items-center justify-between px-6 py-4 border-b border-border/50">
-        <div className="flex items-center gap-2.5">
+    <Panel>
+      <PanelHeader>
+        <PanelHeaderText className="flex-row items-center gap-2.5">
           <Package className="size-4 text-muted-foreground" />
-          <h2 className="font-display text-lg">Export Fragments</h2>
+          <PanelTitle>Export Fragments</PanelTitle>
           {selected.size > 0 && (
             <Badge variant="secondary" className="text-[0.625rem] h-4 tabular-nums">
               {selected.size} selected
             </Badge>
           )}
-        </div>
-        <Button size="icon" variant="ghost" className="size-7 text-muted-foreground" onClick={onClose}>
-          <X className="size-4" />
-        </Button>
-      </div>
+        </PanelHeaderText>
+        <PanelActions>
+          <Button size="icon" variant="ghost" className="size-7 text-muted-foreground" onClick={onClose}>
+            <X className="size-4" />
+          </Button>
+        </PanelActions>
+      </PanelHeader>
 
       {/* Select actions */}
-      <div className="flex items-center gap-3 px-6 py-3 border-b border-border/30">
+      <div className="shrink-0 flex items-center gap-3 px-6 py-3 border-b border-border/30">
         <button
           onClick={allSelected ? deselectAll : selectAll}
           className="text-[0.6875rem] text-muted-foreground hover:text-foreground transition-colors"
@@ -217,9 +227,7 @@ export function FragmentExportPanel({ storyId, storyName, onClose }: FragmentExp
         </span>
       </div>
 
-      {/* Fragment groups */}
-      <ScrollArea className="flex-1 min-h-0">
-        <div className="px-6 py-4 space-y-6">
+      <PanelBody className="px-6 py-4 gap-6">
           {Object.entries(grouped).map(([type, fragments]) => {
             const config = TYPE_CONFIG[type]
             if (!config) return null
@@ -315,17 +323,16 @@ export function FragmentExportPanel({ storyId, storyName, onClose }: FragmentExp
             )
           })}
 
-          {allExportable.length === 0 && (
-            <div className="text-center py-12">
-              <p className="text-sm text-muted-foreground italic">No fragments to export</p>
-              <p className="text-xs text-muted-foreground mt-1">Create some characters, guidelines, or knowledge first</p>
-            </div>
-          )}
-        </div>
-      </ScrollArea>
+        {allExportable.length === 0 && (
+          <div className="text-center py-12">
+            <EmptyHint size="sm">No fragments to export</EmptyHint>
+            <Hint className="mt-1">Create some characters, guidelines, or knowledge first</Hint>
+          </div>
+        )}
+      </PanelBody>
 
       {/* Context config toggle */}
-      <div className="px-6 py-3 border-t border-border/30">
+      <div className="shrink-0 px-6 py-3 border-t border-border/30">
         <div
           onClick={() => setIncludeConfigs((v) => !v)}
           className="flex items-center gap-2.5 cursor-pointer group"
@@ -354,8 +361,7 @@ export function FragmentExportPanel({ storyId, storyName, onClose }: FragmentExp
         )}
       </div>
 
-      {/* Footer actions */}
-      <div className="flex items-center gap-2 px-6 py-4 border-t border-border/50">
+      <PanelFooter className="px-6 py-4 gap-2">
         <Button
           size="sm"
           className="gap-1.5"
@@ -378,7 +384,7 @@ export function FragmentExportPanel({ storyId, storyName, onClose }: FragmentExp
         <Button size="sm" variant="ghost" onClick={onClose}>
           Cancel
         </Button>
-      </div>
-    </div>
+      </PanelFooter>
+    </Panel>
   )
 }

--- a/src/components/fragments/FragmentImportDialog.tsx
+++ b/src/components/fragments/FragmentImportDialog.tsx
@@ -16,15 +16,9 @@ import { Checkbox } from '@/components/ui/checkbox'
 import { Button } from '@/components/ui/button'
 import { Textarea } from '@/components/ui/textarea'
 import { Badge } from '@/components/ui/badge'
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from '@/components/ui/dialog'
-import { Clipboard, FileJson, AlertCircle, ImageIcon, Upload, Package, Settings2 } from 'lucide-react'
+import { FileDropDialog } from '@/components/ui/file-drop-dialog'
+import { Caption } from '@/components/ui/prose-text'
+import { Clipboard, FileJson, ImageIcon, Upload, Package, Settings2 } from 'lucide-react'
 
 interface FragmentImportDialogProps {
   storyId: string
@@ -58,7 +52,6 @@ export function FragmentImportDialog({
   const [importBlockConfig, setImportBlockConfig] = useState(true)
   const [importAgentConfigs, setImportAgentConfigs] = useState<Set<string>>(new Set())
 
-  // Detect available configs in parsed bundle
   const bundleConfigs = useMemo(() => {
     if (!parsed || !isBundle(parsed)) return null
     const hasBlockConfig = !!parsed.blockConfig && !isBlockConfigEmpty(parsed.blockConfig)
@@ -91,7 +84,6 @@ export function FragmentImportDialog({
     }
   }, [parsed, importBlockConfig, importAgentConfigs])
 
-  // Manage dialog state on open/close
   useEffect(() => {
     if (!open) {
       setJsonText('')
@@ -112,7 +104,6 @@ export function FragmentImportDialog({
         initConfigSelections(initialData)
       }
     } else {
-      // Try reading clipboard automatically
       navigator.clipboard.readText().then((text) => {
         const result = parseErrataExport(text)
         if (result) {
@@ -211,21 +202,18 @@ export function FragmentImportDialog({
   const importMutation = useMutation({
     mutationFn: async (data: ErrataExportData) => {
       if (isSingleFragment(data)) {
-        // Legacy single-fragment format: merge attachments into entry
         const entry: FragmentExportEntry = {
           ...data.fragment,
           attachments: data.attachments,
         }
         return [await importFragmentEntry(storyId, entry)]
       } else {
-        // Bundle format: import selected fragments
         const entries = data.fragments.filter((_, i) => selectedIndices.has(i))
         const results = []
         for (const entry of entries) {
           results.push(await importFragmentEntry(storyId, entry))
         }
 
-        // Import configs if any are selected
         const hasConfigsToImport =
           (importBlockConfig && data.blockConfig) ||
           importAgentConfigs.size > 0
@@ -267,127 +255,120 @@ export function FragmentImportDialog({
     : 0
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-lg max-h-[85vh] flex flex-col overflow-hidden">
-        <DialogHeader>
-          <DialogTitle className="flex items-center gap-2">
-            <FileJson className="size-4 text-muted-foreground" />
-            Import Fragments
-          </DialogTitle>
-          <DialogDescription>
-            Paste fragment JSON, drop a file, or load from clipboard.
-          </DialogDescription>
-        </DialogHeader>
+    <FileDropDialog
+      open={open}
+      onOpenChange={onOpenChange}
+      title={
+        <span className="inline-flex items-center gap-2">
+          <FileJson className="size-4 text-muted-foreground" aria-hidden="true" />
+          Import Fragments
+        </span>
+      }
+      description="Paste fragment JSON, drop a file, or load from clipboard."
+      contentClassName="max-w-lg"
+      showCloseButton
+    >
+      {!parsed && (
+        <>
+          <div className="flex gap-1.5">
+            <Button
+              size="sm"
+              variant="outline"
+              className="h-7 text-xs gap-1.5"
+              onClick={handlePasteFromClipboard}
+            >
+              <Clipboard className="size-3" />
+              Paste from clipboard
+            </Button>
+            <label className="inline-flex items-center gap-1.5 h-7 px-3 rounded-md border border-border/40 text-xs cursor-pointer transition-colors hover:bg-accent/50">
+              <Upload className="size-3" />
+              Load file
+              <input
+                type="file"
+                accept=".json,application/json"
+                className="hidden"
+                onChange={handleFileInput}
+              />
+            </label>
+          </div>
 
-        <div className="space-y-3 overflow-y-auto min-h-0 flex-1">
-          {/* Input area - shown when nothing parsed yet */}
-          {!parsed && (
-            <>
-              <div className="flex gap-1.5">
-                <Button
-                  size="sm"
-                  variant="outline"
-                  className="h-7 text-xs gap-1.5"
-                  onClick={handlePasteFromClipboard}
-                >
-                  <Clipboard className="size-3" />
-                  Paste from clipboard
-                </Button>
-                <label className="inline-flex items-center gap-1.5 h-7 px-3 rounded-md border border-border/40 text-xs cursor-pointer transition-colors hover:bg-accent/50">
-                  <Upload className="size-3" />
-                  Load file
-                  <input
-                    type="file"
-                    accept=".json,application/json"
-                    className="hidden"
-                    onChange={handleFileInput}
-                  />
-                </label>
-              </div>
-
-              {/* Drop zone / textarea combo */}
-              <div
-                className="relative"
-                onDragOver={(e) => { e.preventDefault(); setDragOver(true) }}
-                onDragLeave={() => setDragOver(false)}
-                onDrop={handleFileDrop}
-              >
-                <Textarea
-                  value={jsonText}
-                  onChange={(e) => handleTextChange(e.target.value)}
-                  placeholder='Paste JSON or drop a .json file here...'
-                  className={`min-h-[140px] resize-none font-mono text-xs bg-transparent transition-colors ${
-                    dragOver ? 'border-primary/50 bg-primary/5' : ''
-                  }`}
-                />
-                {dragOver && (
-                  <div className="absolute inset-0 flex items-center justify-center rounded-md border-2 border-dashed border-primary/40 bg-primary/5 pointer-events-none">
-                    <div className="text-center">
-                      <Upload className="size-5 text-primary/50 mx-auto mb-1" />
-                      <p className="text-xs text-primary/60">Drop file here</p>
-                    </div>
-                  </div>
-                )}
-              </div>
-            </>
-          )}
-
-          {/* Error */}
-          {parseError && (
-            <div className="flex items-start gap-2 text-xs text-destructive/80 bg-destructive/5 rounded-md px-3 py-2">
-              <AlertCircle className="size-3.5 mt-0.5 shrink-0" />
-              <span>{parseError}</span>
-            </div>
-          )}
-
-          {/* Single fragment preview */}
-          {parsed && isSingleFragment(parsed) && (
-            <SingleFragmentPreview data={parsed} onClear={() => { setParsed(null); setJsonText('') }} />
-          )}
-
-          {/* Bundle preview */}
-          {parsed && isBundle(parsed) && (
-            <BundlePreview
-              data={parsed}
-              selectedIndices={selectedIndices}
-              onToggle={toggleBundleItem}
-              onSelectAll={() => setSelectedIndices(new Set(parsed.fragments.map((_, i) => i)))}
-              onDeselectAll={() => setSelectedIndices(new Set())}
-              onClear={() => { setParsed(null); setJsonText(''); setSelectedIndices(new Set()) }}
-              bundleConfigs={bundleConfigs}
-              importBlockConfig={importBlockConfig}
-              onToggleBlockConfig={() => setImportBlockConfig((v) => !v)}
-              importAgentConfigs={importAgentConfigs}
-              onToggleAgentConfig={(name) => {
-                setImportAgentConfigs((prev) => {
-                  const next = new Set(prev)
-                  if (next.has(name)) next.delete(name)
-                  else next.add(name)
-                  return next
-                })
-              }}
-              scriptImportWarning={scriptImportWarning}
-            />
-          )}
-        </div>
-
-        <DialogFooter>
-          <Button variant="outline" size="sm" onClick={() => onOpenChange(false)}>
-            Cancel
-          </Button>
-          <Button
-            size="sm"
-            disabled={!parsed || importCount === 0 || importMutation.isPending}
-            onClick={() => parsed && importMutation.mutate(parsed)}
+          {/* Drop zone / textarea combo — textarea-first, drop-to-parse */}
+          <div
+            className="relative"
+            onDragOver={(e) => { e.preventDefault(); setDragOver(true) }}
+            onDragLeave={() => setDragOver(false)}
+            onDrop={handleFileDrop}
           >
-            {importMutation.isPending
-              ? 'Importing...'
-              : `Import${importCount > 1 ? ` ${importCount} fragments` : ''}`
-            }
-          </Button>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
+            <Textarea
+              value={jsonText}
+              onChange={(e) => handleTextChange(e.target.value)}
+              placeholder='Paste JSON or drop a .json file here...'
+              className={`min-h-[140px] resize-none font-mono text-xs bg-transparent transition-colors ${
+                dragOver ? 'border-primary/50 bg-primary/5' : ''
+              }`}
+            />
+            {dragOver && (
+              <div className="absolute inset-0 flex items-center justify-center rounded-md border-2 border-dashed border-primary/40 bg-primary/5 pointer-events-none">
+                <div className="text-center">
+                  <Upload className="size-5 text-primary/50 mx-auto mb-1" aria-hidden="true" />
+                  <p className="text-xs text-primary/60 italic font-display">Drop file here</p>
+                </div>
+              </div>
+            )}
+          </div>
+        </>
+      )}
+
+      <FileDropDialog.Errors>{parseError}</FileDropDialog.Errors>
+
+      {parsed && isSingleFragment(parsed) && (
+        <FileDropDialog.Preview>
+          <SingleFragmentPreview data={parsed} onClear={() => { setParsed(null); setJsonText('') }} />
+        </FileDropDialog.Preview>
+      )}
+
+      {parsed && isBundle(parsed) && (
+        <FileDropDialog.Preview>
+          <BundlePreview
+            data={parsed}
+            selectedIndices={selectedIndices}
+            onToggle={toggleBundleItem}
+            onSelectAll={() => setSelectedIndices(new Set(parsed.fragments.map((_, i) => i)))}
+            onDeselectAll={() => setSelectedIndices(new Set())}
+            onClear={() => { setParsed(null); setJsonText(''); setSelectedIndices(new Set()) }}
+            bundleConfigs={bundleConfigs}
+            importBlockConfig={importBlockConfig}
+            onToggleBlockConfig={() => setImportBlockConfig((v) => !v)}
+            importAgentConfigs={importAgentConfigs}
+            onToggleAgentConfig={(name) => {
+              setImportAgentConfigs((prev) => {
+                const next = new Set(prev)
+                if (next.has(name)) next.delete(name)
+                else next.add(name)
+                return next
+              })
+            }}
+            scriptImportWarning={scriptImportWarning}
+          />
+        </FileDropDialog.Preview>
+      )}
+
+      <FileDropDialog.Actions>
+        <Button variant="outline" size="sm" onClick={() => onOpenChange(false)}>
+          Cancel
+        </Button>
+        <Button
+          size="sm"
+          disabled={!parsed || importCount === 0 || importMutation.isPending}
+          onClick={() => parsed && importMutation.mutate(parsed)}
+        >
+          {importMutation.isPending
+            ? 'Importing...'
+            : `Import${importCount > 1 ? ` ${importCount} fragments` : ''}`
+          }
+        </Button>
+      </FileDropDialog.Actions>
+    </FileDropDialog>
   )
 }
 
@@ -414,7 +395,7 @@ export function SingleFragmentPreview({
         <div>
           <p className="font-display text-base leading-tight">{f.name}</p>
           {f.description && (
-            <p className="text-xs text-muted-foreground mt-0.5">{f.description}</p>
+            <Caption className="mt-0.5">{f.description}</Caption>
           )}
         </div>
         {f.content && (
@@ -494,7 +475,6 @@ export function BundlePreview({
 }) {
   const allSelected = data.fragments.length === selectedIndices.size
 
-  // Group by type for display
   const groupedEntries = data.fragments.reduce<Record<string, Array<{ entry: FragmentExportEntry; index: number }>>>((acc, entry, index) => {
     const type = entry.type
     if (!acc[type]) acc[type] = []
@@ -504,7 +484,6 @@ export function BundlePreview({
 
   return (
     <div className="rounded-lg border border-border/50 bg-accent/20 overflow-hidden">
-      {/* Bundle header */}
       <div className="px-4 py-3 border-b border-border/30">
         <div className="flex items-center gap-2">
           <Package className="size-3.5 text-muted-foreground" />
@@ -531,7 +510,6 @@ export function BundlePreview({
         </div>
       </div>
 
-      {/* Fragment list */}
       <div className="max-h-64 overflow-y-auto">
         {Object.entries(groupedEntries).map(([type, items]) => (
           <div key={type}>
@@ -574,7 +552,6 @@ export function BundlePreview({
         ))}
       </div>
 
-      {/* Context configuration section */}
       {bundleConfigs && (
         <div className="border-t border-border/30">
           <div className="px-4 py-2 bg-background/30 border-b border-border/20">
@@ -637,7 +614,6 @@ export function BundlePreview({
         </div>
       )}
 
-      {/* Clear */}
       <div className="border-t border-border/30 px-4 py-2">
         <button
           onClick={onClear}

--- a/src/components/fragments/FragmentList.tsx
+++ b/src/components/fragments/FragmentList.tsx
@@ -7,6 +7,7 @@ import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { ScrollArea } from '@/components/ui/scroll-area'
+import { Spinner, EmptyState } from '@/components/ui/async-view'
 import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
 import {
   DropdownMenu,
@@ -15,6 +16,7 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
 import { Plus, Pin, GripVertical, FileDown, UserPlus, Archive, FolderPlus, ChevronRight, MoreHorizontal, Pencil, Trash2, FolderOpen } from 'lucide-react'
+import { Caption } from '@/components/ui/prose-text'
 
 interface FragmentListProps {
   storyId: string
@@ -161,9 +163,9 @@ const FragmentRow = memo(function FragmentRow({
           )}
         </div>
         {fragment.description && (
-          <p className="text-xs text-muted-foreground truncate mt-0.5">
+          <Caption className="truncate mt-0.5">
             {fragment.description}
-          </p>
+          </Caption>
         )}
       </button>
 
@@ -936,7 +938,11 @@ export function FragmentList({
   const displayList = dragDisplayOrder ?? filtered
 
   if (isLoading) {
-    return <p className="text-sm text-muted-foreground p-4">Loading...</p>
+    return (
+      <div className="flex items-center justify-center p-6">
+        <Spinner size="sm" />
+      </div>
+    )
   }
 
   // Render a list of fragments (used both in flat and grouped views)
@@ -1115,9 +1121,11 @@ export function FragmentList({
           {!useGroupedView && (
             <>
               {displayList.length === 0 && (
-                <p className="text-xs text-muted-foreground py-8 text-center italic">
-                  {search.trim() ? 'No matches' : 'No fragments yet'}
-                </p>
+                <EmptyState
+                  title={search.trim() ? 'No matches' : 'No fragments yet'}
+                  hint={search.trim() ? undefined : 'Create one with the plus above, or let the writing wizard draft a starter set.'}
+                  className="py-8"
+                />
               )}
               {displayList.map((fragment, index) => (
                 <FragmentRow

--- a/src/components/fragments/TavernCardImportDialog.tsx
+++ b/src/components/fragments/TavernCardImportDialog.tsx
@@ -1,15 +1,11 @@
-import { useState, useEffect, useCallback, useRef } from 'react'
+import { useState, useEffect, useCallback } from 'react'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { api } from '@/lib/api'
 import { importTavernCard, isTavernCardPng, parseCardJson, type ImportedCharacter, type ParsedCharacterCard } from '@/lib/importers/tavern-card'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
-import {
-  Dialog,
-  DialogContent,
-  DialogFooter,
-} from '@/components/ui/dialog'
-import { AlertCircle, Check, Plus } from 'lucide-react'
+import { FileDropDialog, FileDropzone } from '@/components/ui/file-drop-dialog'
+import { Check, Plus } from 'lucide-react'
 
 function arrayBufferToDataUrl(buffer: ArrayBuffer): string {
   const bytes = new Uint8Array(buffer)
@@ -45,18 +41,15 @@ export function TavernCardImportDialog({
   onJsonCardDetected,
 }: TavernCardImportDialogProps) {
   const queryClient = useQueryClient()
-  const fileInputRef = useRef<HTMLInputElement>(null)
   const [cards, setCards] = useState<ParsedCard[]>([])
   const [selected, setSelected] = useState<Set<number>>(new Set())
   const [parseError, setParseError] = useState<string | null>(null)
-  const [dragOver, setDragOver] = useState(false)
 
   useEffect(() => {
     if (!open) {
       setCards([])
       setSelected(new Set())
       setParseError(null)
-      setDragOver(false)
       return
     }
     if (initialBuffers && initialBuffers.length > 0) {
@@ -90,7 +83,6 @@ export function TavernCardImportDialog({
     }
     setCards((prev) => {
       const next = [...prev, ...parsed]
-      // Auto-select newly added cards
       setSelected((prevSel) => {
         const s = new Set(prevSel)
         for (let i = prev.length; i < next.length; i++) s.add(i)
@@ -105,19 +97,14 @@ export function TavernCardImportDialog({
     )
   }, [])
 
-  const handleFileInput = useCallback(async (e: React.ChangeEvent<HTMLInputElement>) => {
-    const files = e.target.files
-    if (!files || files.length === 0) return
-
+  const handleFiles = useCallback(async (files: File[]) => {
     // Check if any file is JSON — route to CharacterCardImportDialog
-    for (let i = 0; i < files.length; i++) {
-      const file = files[i]
+    for (const file of files) {
       if (file.name.toLowerCase().endsWith('.json') || file.type === 'application/json') {
         try {
           const text = await file.text()
           const parsed = parseCardJson(text)
           if (parsed && onJsonCardDetected) {
-            e.target.value = ''
             onJsonCardDetected(parsed)
             return
           }
@@ -126,29 +113,13 @@ export function TavernCardImportDialog({
     }
 
     const buffers: ArrayBuffer[] = []
-    for (let i = 0; i < files.length; i++) {
+    for (const file of files) {
       try {
-        buffers.push(await files[i].arrayBuffer())
+        buffers.push(await file.arrayBuffer())
       } catch { /* skip unreadable */ }
     }
     if (buffers.length > 0) parseBuffers(buffers)
-    e.target.value = ''
   }, [parseBuffers, onJsonCardDetected])
-
-  const handleDrop = useCallback(async (e: React.DragEvent) => {
-    e.preventDefault()
-    e.stopPropagation()
-    setDragOver(false)
-    const files = e.dataTransfer.files
-    if (!files || files.length === 0) return
-    const buffers: ArrayBuffer[] = []
-    for (let i = 0; i < files.length; i++) {
-      try {
-        buffers.push(await files[i].arrayBuffer())
-      } catch { /* skip */ }
-    }
-    if (buffers.length > 0) parseBuffers(buffers)
-  }, [parseBuffers])
 
   const toggleCard = useCallback((index: number) => {
     setSelected((prev) => {
@@ -210,198 +181,90 @@ export function TavernCardImportDialog({
   const hasCards = cards.length > 0
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent
-        showCloseButton={false}
-        className={`max-h-[85vh] flex flex-col overflow-hidden p-0 gap-0 border-border/60 bg-card transition-[max-width] duration-300 ${
-          hasCards ? 'max-w-2xl' : 'max-w-[440px]'
-        }`}
-      >
-        {/* ── Header ── */}
-        <div className="px-6 pt-6 pb-4">
-          <p className="font-display text-xl tracking-tight">
-            Import Character Card{hasCards && cards.length > 1 ? 's' : ''}
-          </p>
-          <p className="text-xs text-muted-foreground mt-1">
-            TavernAI &amp; SillyTavern character card PNGs
-          </p>
-        </div>
+    <FileDropDialog
+      open={open}
+      onOpenChange={onOpenChange}
+      title={`Import Character Card${hasCards && cards.length > 1 ? 's' : ''}`}
+      description="TavernAI & SillyTavern character card PNGs"
+      contentClassName={`transition-[max-width] duration-300 ${hasCards ? 'max-w-2xl' : 'max-w-[440px]'}`}
+    >
+      {!hasCards && (
+        <FileDropDialog.Dropzone
+          onFiles={handleFiles}
+          accept="image/png,.png,.json,application/json"
+          multiple
+          label="Drop character cards here"
+          hint="one or multiple .png files"
+          icon={
+            <svg viewBox="0 0 48 56" className="w-12 h-14" aria-hidden="true">
+              <circle cx="24" cy="16" r="8" fill="currentColor" />
+              <ellipse cx="24" cy="48" rx="16" ry="14" fill="currentColor" />
+            </svg>
+          }
+        />
+      )}
 
-        <div className="flex-1 overflow-y-auto min-h-0 px-5 pb-4 space-y-3">
-          {/* ── Drop zone — always visible when no cards, compact "add more" when cards exist ── */}
-          {!hasCards && (
-            <div
-              className={`relative group rounded-xl overflow-hidden cursor-pointer transition-all duration-300 ${
-                dragOver ? 'scale-[0.98]' : 'hover:scale-[0.995]'
-              }`}
-              onDragOver={(e) => { e.preventDefault(); setDragOver(true) }}
-              onDragLeave={() => setDragOver(false)}
-              onDrop={handleDrop}
-              onClick={() => fileInputRef.current?.click()}
-            >
-              {/* Animated dashed border */}
-              <svg className="absolute inset-0 w-full h-full pointer-events-none" preserveAspectRatio="none">
-                <rect
-                  x="1" y="1"
-                  width="calc(100% - 2px)" height="calc(100% - 2px)"
-                  rx="11" ry="11"
-                  fill="none"
-                  className={`transition-all duration-300 ${
-                    dragOver ? 'stroke-primary/50' : 'stroke-border/60 group-hover:stroke-border'
-                  }`}
-                  strokeWidth="1.5"
-                  strokeDasharray="6 6"
-                  style={{ animation: 'tavern-dropzone-dash 1.5s linear infinite' }}
-                />
-              </svg>
-
-              <div className={`relative flex flex-col items-center justify-center py-14 px-8 transition-colors duration-300 ${
-                dragOver ? 'bg-primary/[0.04]' : 'bg-muted/30'
-              }`}>
-                <div className={`relative mb-5 transition-all duration-300 ${
-                  dragOver ? 'scale-110' : 'group-hover:scale-105'
-                }`}>
-                  <div className="w-16 h-20 rounded-lg bg-gradient-to-b from-muted-foreground/[0.07] to-muted-foreground/[0.03] flex items-end justify-center overflow-hidden">
-                    <svg viewBox="0 0 48 56" className={`w-12 h-14 transition-colors duration-300 ${
-                      dragOver ? 'text-primary/30' : 'text-muted-foreground group-hover:text-muted-foreground'
-                    }`}>
-                      <circle cx="24" cy="16" r="8" fill="currentColor" />
-                      <ellipse cx="24" cy="48" rx="16" ry="14" fill="currentColor" />
-                    </svg>
-                  </div>
-                  {dragOver && (
-                    <div
-                      className="absolute -inset-3 rounded-2xl bg-primary/10 blur-lg"
-                      style={{ animation: 'tavern-dropzone-glow 2s ease-in-out infinite' }}
-                    />
-                  )}
-                </div>
-
-                <p className={`font-display text-base tracking-tight transition-colors duration-200 ${
-                  dragOver ? 'text-primary' : 'text-foreground/70 group-hover:text-foreground/80'
-                }`}>
-                  Drop character cards here
-                </p>
-                <p className="text-[0.6875rem] text-muted-foreground mt-1.5">
-                  one or multiple .png files
-                </p>
-              </div>
-            </div>
-          )}
-
-          {/* ── Card grid ── */}
-          {hasCards && (
-            <div
-              className={`grid gap-3 ${cards.length === 1 ? 'grid-cols-1' : 'grid-cols-2'}`}
-              onDragOver={(e) => { e.preventDefault(); setDragOver(true) }}
-              onDragLeave={() => setDragOver(false)}
-              onDrop={handleDrop}
-            >
-              {cards.map((card, index) => (
-                <div
-                  key={`${card.character.name}-${index}`}
-                  className="animate-tavern-card-reveal"
-                  style={{ animationDelay: `${index * 60}ms` }}
-                >
-                  <CharacterCard
-                    card={card}
-                    selected={selected.has(index)}
-                    onToggle={() => toggleCard(index)}
-                    onRemove={() => removeCard(index)}
-                    large={cards.length === 1}
-                  />
-                </div>
-              ))}
-
-              {/* Add more zone */}
+      {hasCards && (
+        <FileDropDialog.Preview>
+          <div className={`grid gap-3 ${cards.length === 1 ? 'grid-cols-1' : 'grid-cols-2'}`}>
+            {cards.map((card, index) => (
               <div
-                className={`relative group rounded-xl overflow-hidden cursor-pointer transition-all duration-200 min-h-40 ${
-                  dragOver ? 'scale-[0.97]' : 'hover:scale-[0.99]'
-                } ${cards.length === 1 ? 'col-span-1' : ''}`}
-                onClick={() => fileInputRef.current?.click()}
+                key={`${card.character.name}-${index}`}
+                className="animate-tavern-card-reveal"
+                style={{ animationDelay: `${index * 60}ms` }}
               >
-                <svg className="absolute inset-0 w-full h-full pointer-events-none" preserveAspectRatio="none">
-                  <rect
-                    x="1" y="1"
-                    width="calc(100% - 2px)" height="calc(100% - 2px)"
-                    rx="11" ry="11"
-                    fill="none"
-                    className={`transition-all duration-300 ${
-                      dragOver ? 'stroke-primary/40' : 'stroke-border/40 group-hover:stroke-border/60'
-                    }`}
-                    strokeWidth="1.5"
-                    strokeDasharray="4 4"
-                    style={{ animation: 'tavern-dropzone-dash 1.5s linear infinite' }}
-                  />
-                </svg>
-                <div className={`h-full flex flex-col items-center justify-center gap-2 py-8 transition-colors ${
-                  dragOver ? 'bg-primary/[0.04]' : 'bg-muted/20'
-                }`}>
-                  <Plus className={`size-5 transition-colors ${
-                    dragOver ? 'text-primary/40' : 'text-muted-foreground group-hover:text-muted-foreground'
-                  }`} />
-                  <p className="text-[0.6875rem] text-muted-foreground group-hover:text-muted-foreground transition-colors">
-                    Add more cards
-                  </p>
-                </div>
+                <CharacterCard
+                  card={card}
+                  selected={selected.has(index)}
+                  onToggle={() => toggleCard(index)}
+                  onRemove={() => removeCard(index)}
+                  large={cards.length === 1}
+                />
               </div>
-            </div>
-          )}
+            ))}
 
-          {/* Hidden file input — always present */}
-          <input
-            ref={fileInputRef}
-            type="file"
-            accept="image/png,.png,.json,application/json"
-            multiple
-            className="hidden"
-            onChange={handleFileInput}
-          />
-
-          {/* Error / warning */}
-          {parseError && (
-            <div className="flex items-start gap-2 text-xs text-destructive/80 bg-destructive/5 rounded-lg px-3 py-2.5">
-              <AlertCircle className="size-3.5 mt-0.5 shrink-0" />
-              <span>{parseError}</span>
-            </div>
-          )}
-        </div>
-
-        {/* ── Ornamental divider ── */}
-        <div className="px-6">
-          <div className="h-px bg-gradient-to-r from-transparent via-border/60 to-transparent" />
-        </div>
-
-        {/* ── Footer ── */}
-        <DialogFooter className="px-5 py-3.5 flex-row items-center">
-          {hasCards && (
-            <span className="text-[0.6875rem] text-muted-foreground mr-auto tabular-nums">
-              {selected.size} of {cards.length} selected
-            </span>
-          )}
-          <Button variant="ghost" size="sm" className="text-muted-foreground" onClick={() => onOpenChange(false)}>
-            Cancel
-          </Button>
-          {hasCards && (
-            <Button
-              size="sm"
-              disabled={selected.size === 0 || importMutation.isPending}
-              onClick={() => importMutation.mutate(selectedCards)}
-              className="gap-1.5"
+            <FileDropzone
+              onFiles={handleFiles}
+              accept="image/png,.png,.json,application/json"
+              multiple
+              className={`min-h-40 ${cards.length === 1 ? 'col-span-1' : ''}`}
             >
-              {importMutation.isPending ? (
-                'Importing\u2026'
-              ) : (
-                <>
-                  <Check className="size-3.5" />
-                  Import{selected.size > 1 ? ` ${selected.size} Characters` : ' Character'}
-                </>
-              )}
-            </Button>
-          )}
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
+              <div className="flex flex-col items-center justify-center gap-2 py-4 text-muted-foreground">
+                <Plus className="size-5" aria-hidden="true" />
+                <p className="text-[0.6875rem]">Add more cards</p>
+              </div>
+            </FileDropzone>
+          </div>
+        </FileDropDialog.Preview>
+      )}
+
+      <FileDropDialog.Errors>{parseError}</FileDropDialog.Errors>
+
+      <FileDropDialog.Actions
+        meta={hasCards ? `${selected.size} of ${cards.length} selected` : undefined}
+      >
+        <Button variant="ghost" size="sm" className="text-muted-foreground" onClick={() => onOpenChange(false)}>
+          Cancel
+        </Button>
+        {hasCards && (
+          <Button
+            size="sm"
+            disabled={selected.size === 0 || importMutation.isPending}
+            onClick={() => importMutation.mutate(selectedCards)}
+            className="gap-1.5"
+          >
+            {importMutation.isPending ? (
+              'Importing\u2026'
+            ) : (
+              <>
+                <Check className="size-3.5" />
+                Import{selected.size > 1 ? ` ${selected.size} Characters` : ' Character'}
+              </>
+            )}
+          </Button>
+        )}
+      </FileDropDialog.Actions>
+    </FileDropDialog>
   )
 }
 

--- a/src/components/generation/DebugPanel.tsx
+++ b/src/components/generation/DebugPanel.tsx
@@ -4,9 +4,11 @@ import { api, type GenerationLog, type GenerationLogSummary } from '@/lib/api'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
 import { ScrollArea } from '@/components/ui/scroll-area'
+import { Spinner, EmptyState } from '@/components/ui/async-view'
 import { StreamMarkdown } from '@/components/ui/stream-markdown'
 import { BlockContentView } from '@/components/blocks/BlockContentView'
 import { X, ChevronDown, ChevronRight, Copy, Check, Brain, FileText } from 'lucide-react'
+import { EmptyHint } from '@/components/ui/prose-text'
 import { cn } from '@/lib/utils'
 
 interface DebugPanelProps {
@@ -62,7 +64,7 @@ export function DebugPanel({ storyId, logId, fragmentId, onClose }: DebugPanelPr
             <ScrollArea className="flex-1">
               <div className="p-1.5 space-y-0.5">
                 {(!logs || logs.length === 0) && (
-                  <p className="text-xs text-muted-foreground py-8 text-center italic">No logs yet</p>
+                  <EmptyState title="No logs yet" className="py-8" />
                 )}
                 {logs?.map((log) => (
                   <LogListItem
@@ -153,11 +155,11 @@ export function DebugPanel({ storyId, logId, fragmentId, onClose }: DebugPanelPr
             </>
           ) : logLoading ? (
             <div className="flex items-center justify-center flex-1">
-              <p className="text-sm text-muted-foreground italic">Loading log...</p>
+              <Spinner />
             </div>
           ) : (
             <div className="flex items-center justify-center flex-1">
-              <p className="text-sm text-muted-foreground italic">Select a generation log to inspect</p>
+              <EmptyHint size="sm" className="font-display">Select a generation log to inspect</EmptyHint>
             </div>
           )}
         </div>
@@ -305,9 +307,9 @@ function ToolsTab({ log }: { log: GenerationLog }) {
 
   if (log.toolCalls.length === 0) {
     return (
-      <p className="text-xs text-muted-foreground text-center py-16 italic">
+      <EmptyHint className="text-center py-16">
         No tool calls were made during this generation.
-      </p>
+      </EmptyHint>
     )
   }
 

--- a/src/components/generation/GenerationPanel.tsx
+++ b/src/components/generation/GenerationPanel.tsx
@@ -4,6 +4,13 @@ import { api } from '@/lib/api'
 import { Button } from '@/components/ui/button'
 import { Textarea } from '@/components/ui/textarea'
 import { StreamMarkdown } from '@/components/ui/stream-markdown'
+import {
+  Panel,
+  PanelActions,
+  PanelHeader,
+  PanelHeaderText,
+  PanelTitle,
+} from '@/components/ui/panel'
 import { DebugPanel } from './DebugPanel'
 import { Send, Eye, Square, Bug, ArrowLeft } from 'lucide-react'
 
@@ -80,10 +87,12 @@ export function GenerationPanel({ storyId, onBack }: GenerationPanelProps) {
   }, [])
 
   return (
-    <div className="flex flex-col h-full" data-component-id="generation-panel-root">
-      <div className="flex items-center justify-between px-6 py-4 border-b border-border/50">
-        <h2 className="font-display text-lg">Generate</h2>
-        <div className="flex gap-1.5">
+    <Panel data-component-id="generation-panel-root">
+      <PanelHeader>
+        <PanelHeaderText>
+          <PanelTitle>Generate</PanelTitle>
+        </PanelHeaderText>
+        <PanelActions>
           <Button
             size="sm"
             variant={showDebug ? 'secondary' : 'ghost'}
@@ -100,8 +109,8 @@ export function GenerationPanel({ storyId, onBack }: GenerationPanelProps) {
               Back
             </Button>
           )}
-        </div>
-      </div>
+        </PanelActions>
+      </PanelHeader>
 
       {showDebug ? (
         <DebugPanel
@@ -184,6 +193,6 @@ export function GenerationPanel({ storyId, onBack }: GenerationPanelProps) {
           </div>
         </>
       )}
-    </div>
+    </Panel>
   )
 }

--- a/src/components/librarian/LibrarianChat.tsx
+++ b/src/components/librarian/LibrarianChat.tsx
@@ -5,6 +5,7 @@ import { Button } from '@/components/ui/button'
 import { Textarea } from '@/components/ui/textarea'
 import { ScrollArea } from '@/components/ui/scroll-area'
 import { Send, Loader2 } from 'lucide-react'
+import { EmptyHint } from '@/components/ui/prose-text'
 import {
   AssistantMessageView,
   type AssistantMessage,
@@ -221,9 +222,9 @@ export function LibrarianChat({ storyId, conversationId, initialInput }: Librari
         <div className="p-3 space-y-3">
           {messages.length === 0 && (
             <div className="flex flex-col items-center justify-center py-12 text-center" data-component-id="librarian-chat-empty">
-              <p className="text-xs text-muted-foreground italic max-w-[240px]">
+              <EmptyHint className="max-w-[240px]">
                 Ask the librarian to make changes across your story — update characters, adjust guidelines, or reshape knowledge.
-              </p>
+              </EmptyHint>
             </div>
           )}
 

--- a/src/components/onboarding/OnboardingWizard.tsx
+++ b/src/components/onboarding/OnboardingWizard.tsx
@@ -9,7 +9,6 @@ import {
   Layers,
   Sparkles,
   Puzzle,
-  ArrowLeft,
   RefreshCw,
   Loader2,
   Zap,
@@ -18,6 +17,8 @@ import {
   BookOpen,
   GitBranch,
 } from 'lucide-react'
+import { Hint, Caption } from '@/components/ui/prose-text'
+import { Wizard } from '@/components/ui/wizard'
 
 // ── Guilloche background ─────────────────────────────
 
@@ -186,39 +187,49 @@ export function OnboardingWizard({ onComplete }: OnboardingWizardProps) {
   return (
     <div className="fixed inset-0 bg-background z-50" data-component-id="onboarding-root">
       <GuillocheBackground />
-      <div className="relative z-10 flex items-center justify-center h-full overflow-auto">
-        {step === 'theme' && (
-          <ThemeStep
-            onNext={() => setStep('typography')}
-          />
-        )}
-        {step === 'typography' && (
-          <TypographyStep
-            onNext={() => setStep('welcome')}
-            onBack={() => setStep('theme')}
-          />
-        )}
-        {step === 'welcome' && (
-          <WelcomeStep
-            onNext={() => setStep('provider-select')}
-          />
-        )}
-        {step === 'provider-select' && (
-          <ProviderSelectStep
-            onSelect={(preset) => {
-              setSelectedPreset(preset)
-              setStep('provider-setup')
-            }}
-            onBack={() => setStep('welcome')}
-          />
-        )}
-        {step === 'provider-setup' && selectedPreset && (
-          <ProviderSetupStep
-            preset={selectedPreset}
-            onComplete={onComplete}
-            onBack={() => setStep('provider-select')}
-          />
-        )}
+      <div className="relative z-10 h-full overflow-auto">
+        <Wizard step={step}>
+          <Wizard.Step stepKey="theme" transition="fade">
+            <div className="flex items-center justify-center min-h-full">
+              <ThemeStep onNext={() => setStep('typography')} />
+            </div>
+          </Wizard.Step>
+          <Wizard.Step stepKey="typography" transition="fade">
+            <div className="flex items-center justify-center min-h-full">
+              <TypographyStep
+                onNext={() => setStep('welcome')}
+                onBack={() => setStep('theme')}
+              />
+            </div>
+          </Wizard.Step>
+          <Wizard.Step stepKey="welcome" transition="fade">
+            <div className="flex items-center justify-center min-h-full">
+              <WelcomeStep onNext={() => setStep('provider-select')} />
+            </div>
+          </Wizard.Step>
+          <Wizard.Step stepKey="provider-select" transition="fade">
+            <div className="flex items-center justify-center min-h-full">
+              <ProviderSelectStep
+                onSelect={(preset) => {
+                  setSelectedPreset(preset)
+                  setStep('provider-setup')
+                }}
+                onBack={() => setStep('welcome')}
+              />
+            </div>
+          </Wizard.Step>
+          <Wizard.Step stepKey="provider-setup" transition="fade">
+            {selectedPreset && (
+              <div className="flex items-center justify-center min-h-full">
+                <ProviderSetupStep
+                  preset={selectedPreset}
+                  onComplete={onComplete}
+                  onBack={() => setStep('provider-select')}
+                />
+              </div>
+            )}
+          </Wizard.Step>
+        </Wizard>
       </div>
     </div>
   )
@@ -331,9 +342,9 @@ function TypographyStep({
     <div className="max-w-xl mx-auto px-6">
       <div className="text-center mb-10 animate-onboarding-fade-up">
         <h2 className="font-display text-3xl italic mb-2">Choose your typeface</h2>
-        <p className="text-sm text-muted-foreground">
+        <Caption size="sm">
           The reading font shapes your entire writing experience.
-        </p>
+        </Caption>
       </div>
 
       {/* Prose fonts — the main event */}
@@ -440,12 +451,7 @@ function TypographyStep({
           Continue
         </Button>
         <div className="mt-4">
-          <button
-            onClick={onBack}
-            className="text-xs text-muted-foreground hover:text-muted-foreground transition-colors flex items-center gap-1"
-          >
-            <ArrowLeft className="size-3" /> Back
-          </button>
+          <Wizard.BackButton tone="link" onBack={onBack} />
         </div>
       </div>
     </div>
@@ -489,10 +495,10 @@ function WelcomeStep({
             <BookOpen className="size-5 text-primary" />
           </div>
           <p className="text-sm font-medium mb-1">The Librarian</p>
-          <p className="text-xs text-muted-foreground leading-relaxed">
+          <Hint className="leading-relaxed">
             A background AI reads every generation &mdash; tracking characters,
             contradictions, and world details into a living story reference.
-          </p>
+          </Hint>
         </div>
         <div
           className="text-left p-5 rounded-xl border border-primary/15 bg-primary/[0.03] animate-onboarding-fade-up"
@@ -502,10 +508,10 @@ function WelcomeStep({
             <GitBranch className="size-5 text-primary" />
           </div>
           <p className="text-sm font-medium mb-1">Timelines</p>
-          <p className="text-xs text-muted-foreground leading-relaxed">
+          <Hint className="leading-relaxed">
             Fork at any point to explore alternate paths. Each timeline
             carries its own fragments, prose, and accumulated knowledge.
-          </p>
+          </Hint>
         </div>
       </div>
 
@@ -526,7 +532,7 @@ function WelcomeStep({
             </div>
             <div>
               <p className="text-sm font-medium mb-0.5">{f.title}</p>
-              <p className="text-xs text-muted-foreground leading-relaxed">{f.desc}</p>
+              <Hint className="leading-relaxed">{f.desc}</Hint>
             </div>
           </div>
         ))}
@@ -559,9 +565,9 @@ function ProviderSelectStep({
     <div className="max-w-2xl mx-auto px-6">
       <div className="text-center mb-8 animate-onboarding-fade-up">
         <h2 className="font-display text-3xl italic mb-2">Choose your provider</h2>
-        <p className="text-sm text-muted-foreground">
+        <Caption size="sm">
           Pick an LLM provider to power your writing. You can always add more later.
-        </p>
+        </Caption>
       </div>
 
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
@@ -592,9 +598,9 @@ function ProviderSelectStep({
                       </span>
                     )}
                   </div>
-                  <p className="text-xs text-muted-foreground leading-relaxed">
+                  <Hint className="leading-relaxed">
                     {card.description}
-                  </p>
+                  </Hint>
                 </div>
               </div>
             </button>
@@ -606,12 +612,7 @@ function ProviderSelectStep({
         className="flex items-center justify-center mt-8 animate-onboarding-fade-up"
         style={{ animationDelay: '500ms' }}
       >
-        <button
-          onClick={onBack}
-          className="text-xs text-muted-foreground hover:text-muted-foreground transition-colors flex items-center gap-1"
-        >
-          <ArrowLeft className="size-3" /> Back
-        </button>
+        <Wizard.BackButton tone="link" onBack={onBack} />
       </div>
     </div>
   )
@@ -745,13 +746,14 @@ function ProviderSetupStep({
         >
           You're all set!
         </h2>
-        <p
-          className="text-sm text-muted-foreground mb-8 animate-onboarding-fade-up"
+        <Caption
+          size="sm"
+          className="mb-8 animate-onboarding-fade-up"
           style={{ animationDelay: '350ms' }}
         >
           {card.name || name} is configured and ready to go. You can manage providers anytime in
           settings.
-        </p>
+        </Caption>
         <div className="animate-onboarding-fade-up" style={{ animationDelay: '500ms' }}>
           <Button onClick={onComplete} className="px-8">
             Start Writing
@@ -773,9 +775,9 @@ function ProviderSetupStep({
             {preset === 'custom' ? 'Custom Provider' : card.name}
           </h2>
         </div>
-        <p className="text-sm text-muted-foreground">
+        <Caption size="sm">
           Enter your credentials to get started.
-        </p>
+        </Caption>
       </div>
 
       <div
@@ -928,12 +930,7 @@ function ProviderSetupStep({
         className="flex items-center justify-center mt-8 animate-onboarding-fade-up"
         style={{ animationDelay: '250ms' }}
       >
-        <button
-          onClick={onBack}
-          className="text-xs text-muted-foreground hover:text-muted-foreground transition-colors flex items-center gap-1"
-        >
-          <ArrowLeft className="size-3" /> Back
-        </button>
+        <Wizard.BackButton tone="link" onBack={onBack} />
       </div>
     </div>
   )

--- a/src/components/prose/ProseBlock.tsx
+++ b/src/components/prose/ProseBlock.tsx
@@ -8,6 +8,7 @@ import { GenerationThoughts } from './GenerationThoughts'
 import { type ThoughtStep } from './InlineGenerationInput'
 import { buildAnnotationHighlighter, formatDialogue, composeTextTransforms, stripEmphasisInDialogue, type Annotation } from '@/lib/character-mentions'
 import { RefreshCw, Undo2, PenLine, Bug, Trash2, GitBranch, MessageSquare, ChevronLeft, ChevronRight, Info, BookOpen } from 'lucide-react'
+import { Caption } from '@/components/ui/prose-text'
 
 interface ProseBlockProps {
   storyId: string
@@ -479,9 +480,9 @@ export const ProseBlock = memo(function ProseBlock({
               title="Click to edit prompt and regenerate"
             >
               <div className="w-0.5 min-h-[1.25rem] rounded-full bg-primary/20 group-hover/prompt:bg-primary/45 transition-colors shrink-0 mt-0.5" />
-              <span className="font-display italic text-sm text-muted-foreground group-hover/prompt:text-muted-foreground truncate transition-colors">
-                {generatedFrom || fragment.description}
-              </span>
+              <Caption asChild size="sm" className="font-display italic group-hover/prompt:text-muted-foreground truncate transition-colors">
+                <span>{generatedFrom || fragment.description}</span>
+              </Caption>
               <RefreshCw className="size-3 shrink-0 mt-1 opacity-0 group-hover/prompt:opacity-40 transition-opacity" />
               {hasMultiple && (
                 <span className="text-[0.625rem] font-mono text-muted-foreground shrink-0 ml-auto mt-0.5">{variationIndex + 1}/{variationCount}</span>
@@ -490,7 +491,7 @@ export const ProseBlock = memo(function ProseBlock({
           ) : (
             <div className="flex items-start gap-2.5">
               <div className="w-0.5 min-h-[1.25rem] rounded-full bg-border/30 shrink-0 mt-0.5" />
-              <span className="font-display italic text-sm text-muted-foreground truncate">{fragment.description}</span>
+              <Caption asChild size="sm" className="font-display italic truncate"><span>{fragment.description}</span></Caption>
               {hasMultiple && (
                 <span className="text-[0.625rem] font-mono text-muted-foreground shrink-0 ml-auto mt-0.5">{variationIndex + 1}/{variationCount}</span>
               )}

--- a/src/components/prose/ProseChainView.tsx
+++ b/src/components/prose/ProseChainView.tsx
@@ -5,6 +5,7 @@ import { api, type Fragment, type ProseChainEntry } from '@/lib/api'
 import { ScrollArea } from '@/components/ui/scroll-area'
 import { StreamMarkdown } from '@/components/ui/stream-markdown'
 import { Loader2, Wand2, Bookmark } from 'lucide-react'
+import { Hint } from '@/components/ui/prose-text'
 import { useQuickSwitch, useProseWidth, PROSE_WIDTH_VALUES, useCharacterMentions } from '@/lib/theme'
 import { ProseBlock } from './ProseBlock'
 import { ChapterMarker } from './ChapterMarker'
@@ -631,9 +632,9 @@ export function ProseChainView({
               <p className="font-display text-2xl italic text-muted-foreground mb-2">
                 The page awaits.
               </p>
-              <p className="text-sm text-muted-foreground mb-8 max-w-xs leading-relaxed">
+              <Hint size="sm" className="mb-8 max-w-xs leading-relaxed">
                 Write your first passage below, or let the wizard help you set up your story.
-              </p>
+              </Hint>
               {onLaunchWizard && (
                 <button
                   onClick={onLaunchWizard}

--- a/src/components/prose/ProseWritingPanel.tsx
+++ b/src/components/prose/ProseWritingPanel.tsx
@@ -25,6 +25,7 @@ import {
 } from 'lucide-react'
 import { useWritingTransforms } from '@/lib/theme'
 import { cn } from '@/lib/utils'
+import { Caption } from '@/components/ui/prose-text'
 
 type SelectionTransformMode = 'rewrite' | 'expand' | 'compress' | 'custom'
 
@@ -594,9 +595,9 @@ export function ProseWritingPanel({
           <div className="flex items-center gap-3 min-w-0">
             <Wand2 className="size-4 text-primary/60 shrink-0" />
             {currentFragment?.description ? (
-              <span className="font-display italic text-sm text-muted-foreground truncate max-w-[40ch]">
-                {currentFragment.description}
-              </span>
+              <Caption asChild size="sm" className="font-display italic truncate max-w-[40ch]">
+                <span>{currentFragment.description}</span>
+              </Caption>
             ) : (
               <span className="font-display text-sm text-muted-foreground">
                 Writing Panel

--- a/src/components/prose/VariationSwitcher.tsx
+++ b/src/components/prose/VariationSwitcher.tsx
@@ -10,6 +10,7 @@ import {
 } from '@/components/ui/dropdown-menu'
 import { Badge } from '@/components/ui/badge'
 import { History, Check, ChevronDown } from 'lucide-react'
+import { Caption } from '@/components/ui/prose-text'
 
 interface VariationSwitcherProps {
   storyId: string
@@ -74,9 +75,9 @@ export function VariationSwitcher({ storyId, sectionIndex, entry }: VariationSwi
                     </Badge>
                   )}
                 </div>
-                <p className="text-xs text-muted-foreground mt-0.5 truncate">
+                <Caption className="mt-0.5 truncate">
                   {fragment.description || fragment.name}
-                </p>
+                </Caption>
                 <p className="text-[0.625rem] text-muted-foreground">
                   {new Date(fragment.createdAt).toLocaleDateString()}
                 </p>

--- a/src/components/settings/CustomCssPanel.tsx
+++ b/src/components/settings/CustomCssPanel.tsx
@@ -1,8 +1,16 @@
 import { useState, useEffect, useCallback } from 'react'
 import { Button } from '@/components/ui/button'
-import { ScrollArea } from '@/components/ui/scroll-area'
 import { Textarea } from '@/components/ui/textarea'
 import { X, Code2, RotateCcw, Save } from 'lucide-react'
+import { Hint } from '@/components/ui/prose-text'
+import {
+  Panel,
+  PanelActions,
+  PanelBody,
+  PanelHeader,
+  PanelHeaderText,
+  PanelTitle,
+} from '@/components/ui/panel'
 import { useCustomCss } from '@/lib/theme'
 
 interface CustomCssPanelProps {
@@ -27,23 +35,25 @@ export function CustomCssPanel({ onClose }: CustomCssPanelProps) {
   }, [])
 
   return (
-    <div className="flex flex-col h-full" data-component-id="custom-css-panel-root">
-      <div className="flex items-center justify-between px-6 py-4 border-b border-border/50">
-        <div className="flex items-center gap-2">
+    <Panel data-component-id="custom-css-panel-root">
+      <PanelHeader>
+        <PanelHeaderText className="flex-row items-center gap-2">
           <Code2 className="size-4 text-muted-foreground" />
-          <h2 className="font-display text-lg">Custom CSS</h2>
+          <PanelTitle>Custom CSS</PanelTitle>
           <span className="text-[0.625rem] text-muted-foreground uppercase tracking-wider">Appearance</span>
-        </div>
-        <Button size="icon" variant="ghost" className="size-7 text-muted-foreground" onClick={onClose} data-component-id="custom-css-panel-close">
-          <X className="size-4" />
-        </Button>
-      </div>
+        </PanelHeaderText>
+        <PanelActions>
+          <Button size="icon" variant="ghost" className="size-7 text-muted-foreground" onClick={onClose} data-component-id="custom-css-panel-close">
+            <X className="size-4" />
+          </Button>
+        </PanelActions>
+      </PanelHeader>
 
-      <ScrollArea className="flex-1" data-component-id="custom-css-panel-scroll">
-        <div className="max-w-3xl mx-auto p-6 space-y-4">
-          <p className="text-sm text-muted-foreground">
+      <PanelBody className="px-6 py-6" data-component-id="custom-css-panel-scroll">
+        <div className="max-w-3xl w-full mx-auto space-y-4">
+          <Hint size="sm">
             Add your own CSS to customize the interface. Styles are applied globally when Custom CSS is enabled.
-          </p>
+          </Hint>
 
           <Textarea
             value={value}
@@ -71,8 +81,8 @@ export function CustomCssPanel({ onClose }: CustomCssPanelProps) {
             </div>
           </div>
         </div>
-      </ScrollArea>
-    </div>
+      </PanelBody>
+    </Panel>
   )
 }
 

--- a/src/components/settings/CustomTransformsPanel.tsx
+++ b/src/components/settings/CustomTransformsPanel.tsx
@@ -1,7 +1,15 @@
 import { useState, useRef, useCallback } from 'react'
 import { Button } from '@/components/ui/button'
-import { ScrollArea } from '@/components/ui/scroll-area'
 import { X, RotateCcw, Plus, Trash2, ChevronDown, ChevronRight, GripVertical } from 'lucide-react'
+import { Hint } from '@/components/ui/prose-text'
+import {
+  Panel,
+  PanelActions,
+  PanelBody,
+  PanelHeader,
+  PanelHeaderText,
+  PanelTitle,
+} from '@/components/ui/panel'
 import { useWritingTransforms, type WritingTransform } from '@/lib/theme'
 
 interface CustomTransformsPanelProps {
@@ -71,22 +79,24 @@ export function CustomTransformsPanel({ onClose }: CustomTransformsPanelProps) {
   }
 
   return (
-    <div className="flex flex-col h-full" data-component-id="custom-transforms-panel-root">
-      <div className="flex items-center justify-between px-6 py-4 border-b border-border/50">
-        <div className="flex items-center gap-2">
-          <h2 className="font-display text-lg">Selection Transforms</h2>
+    <Panel data-component-id="custom-transforms-panel-root">
+      <PanelHeader>
+        <PanelHeaderText className="flex-row items-center gap-2">
+          <PanelTitle>Selection Transforms</PanelTitle>
           <span className="text-[0.625rem] text-muted-foreground uppercase tracking-wider">Writing</span>
-        </div>
-        <Button size="icon" variant="ghost" className="size-7 text-muted-foreground" onClick={onClose}>
-          <X className="size-4" />
-        </Button>
-      </div>
+        </PanelHeaderText>
+        <PanelActions>
+          <Button size="icon" variant="ghost" className="size-7 text-muted-foreground" onClick={onClose}>
+            <X className="size-4" />
+          </Button>
+        </PanelActions>
+      </PanelHeader>
 
-      <ScrollArea className="flex-1">
-        <div className="max-w-3xl mx-auto p-6 space-y-4">
-          <p className="text-sm text-muted-foreground">
+      <PanelBody className="px-6 py-6">
+        <div className="max-w-3xl w-full mx-auto space-y-4">
+          <Hint size="sm">
             Custom transforms appear in the floating toolbar when you select text in the writing panel. Drag to reorder, toggle to show/hide.
-          </p>
+          </Hint>
 
           <div className="space-y-1">
             {transforms.map((t, index) => {
@@ -185,7 +195,7 @@ export function CustomTransformsPanel({ onClose }: CustomTransformsPanelProps) {
             </Button>
           </div>
         </div>
-      </ScrollArea>
-    </div>
+      </PanelBody>
+    </Panel>
   )
 }

--- a/src/components/settings/ProviderManager.tsx
+++ b/src/components/settings/ProviderManager.tsx
@@ -4,6 +4,7 @@ import { api, type ProviderConfigSafe } from '@/lib/api'
 import { Button } from '@/components/ui/button'
 import { ScrollArea } from '@/components/ui/scroll-area'
 import { Plus, Trash2, Star, Pencil, RefreshCw, Loader2, X, ArrowLeft, Minus, Zap, Copy } from 'lucide-react'
+import { EmptyHint, Hint } from '@/components/ui/prose-text'
 
 const PRESETS = {
   deepseek: { name: 'DeepSeek', baseURL: 'https://api.deepseek.com', defaultModel: 'deepseek-chat' },
@@ -46,7 +47,7 @@ export function ProviderList({ onManage }: { onManage: () => void }) {
   return (
     <div className="space-y-2">
       {providers.length === 0 ? (
-        <p className="text-xs text-muted-foreground italic">No providers configured. Using DeepSeek via environment variable.</p>
+        <EmptyHint>No providers configured. Using DeepSeek via environment variable.</EmptyHint>
       ) : (
         providers.map((p) => (
           <div key={p.id} className="flex items-center gap-1.5 py-0.5">
@@ -511,8 +512,8 @@ export function ProviderPanel({ onClose }: { onClose: () => void }) {
           <div className="max-w-2xl mx-auto p-6 space-y-2">
             {providers.length === 0 && (
               <div className="text-center py-12">
-                <p className="text-sm text-muted-foreground italic mb-4">No providers configured.</p>
-                <p className="text-xs text-muted-foreground mb-6">Using DeepSeek via environment variable as fallback.</p>
+                <EmptyHint size="sm" className="mb-4">No providers configured.</EmptyHint>
+                <Hint className="mb-6">Using DeepSeek via environment variable as fallback.</Hint>
                 <Button size="sm" variant="outline" className="gap-1.5" onClick={openAdd}>
                   <Plus className="size-3" /> Add your first provider
                 </Button>

--- a/src/components/sidebar/ArchivePanel.tsx
+++ b/src/components/sidebar/ArchivePanel.tsx
@@ -5,6 +5,7 @@ import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Badge } from '@/components/ui/badge'
 import { ScrollArea } from '@/components/ui/scroll-area'
+import { Spinner, EmptyState } from '@/components/ui/async-view'
 import { Undo2, Trash2, Archive } from 'lucide-react'
 import { componentId } from '@/lib/dom-ids'
 
@@ -58,14 +59,18 @@ export function ArchivePanel({ storyId }: ArchivePanelProps) {
       <ScrollArea className="flex-1" data-component-id="archive-scroll">
         <div className="px-3 pb-3 space-y-1">
           {isLoading && (
-            <p className="text-xs text-muted-foreground text-center py-8">Loading...</p>
+            <div className="flex items-center justify-center py-8">
+              <Spinner size="sm" />
+            </div>
           )}
 
           {!isLoading && filtered.length === 0 && (
-            <div className="flex flex-col items-center justify-center py-12 text-muted-foreground" data-component-id="archive-empty">
-              <Archive className="size-8 mb-2" />
-              <p className="text-xs">No archived fragments</p>
-            </div>
+            <EmptyState
+              icon={<Archive className="size-5" />}
+              title={search.trim() ? 'No matches' : 'Nothing archived'}
+              hint={search.trim() ? undefined : 'Archived fragments appear here — drag a fragment onto the archive, or send it here from its menu.'}
+              className="py-10"
+            />
           )}
 
           {filtered.map((fragment) => (

--- a/src/components/sidebar/TimelineManagerPanel.tsx
+++ b/src/components/sidebar/TimelineManagerPanel.tsx
@@ -4,6 +4,7 @@ import { api, type BranchMeta } from '@/lib/api'
 import { Button } from '@/components/ui/button'
 import { ScrollArea } from '@/components/ui/scroll-area'
 import { GitBranch, Plus, Pencil, Trash2, Check, X } from 'lucide-react'
+import { MetaLabel } from '@/components/ui/prose-text'
 
 interface TimelineManagerPanelProps {
   storyId: string
@@ -79,9 +80,11 @@ export function TimelineManagerPanel({ storyId }: TimelineManagerPanelProps) {
     <ScrollArea className="h-full">
       <div className="p-4 space-y-4">
         <div className="flex items-center justify-between">
-          <p className="text-xs text-muted-foreground">
-            {branches.length} {branches.length === 1 ? 'timeline' : 'timelines'}
-          </p>
+          <MetaLabel asChild>
+            <p>
+              {branches.length} {branches.length === 1 ? 'timeline' : 'timelines'}
+            </p>
+          </MetaLabel>
           <Button
             size="sm"
             variant="outline"

--- a/src/components/ui/async-view.tsx
+++ b/src/components/ui/async-view.tsx
@@ -1,0 +1,107 @@
+import type { ReactNode } from 'react'
+import { cn } from '@/lib/utils'
+import { ErrataMark } from '@/components/ErrataLogo'
+
+/**
+ * Async-state primitives: a thin rotating Spinner and a bookish EmptyState.
+ * Motion respects `prefers-reduced-motion` — see `.animate-spinner-rotate`
+ * in styles.css.
+ */
+
+interface SpinnerProps {
+  size?: 'sm' | 'md'
+  className?: string
+  label?: string
+}
+
+/**
+ * A single thin rotating arc. With reduced motion, degrades to a static
+ * errata mark at low opacity.
+ */
+export function Spinner({ size = 'md', className, label = 'Loading' }: SpinnerProps) {
+  const px = size === 'sm' ? 14 : 20
+  const stroke = size === 'sm' ? 1.25 : 1.5
+  const r = (px - stroke) / 2
+  const c = px / 2
+
+  return (
+    <span
+      role="status"
+      aria-label={label}
+      className={cn('inline-flex items-center justify-center text-muted-foreground/60', className)}
+      style={{ width: px, height: px }}
+    >
+      {/* Reduced-motion fallback: a still errata mark (not a frozen wheel) */}
+      <ErrataMark
+        size={px}
+        className="motion-reduce:block hidden opacity-40"
+      />
+      <svg
+        className="motion-reduce:hidden animate-spinner-rotate"
+        width={px}
+        height={px}
+        viewBox={`0 0 ${px} ${px}`}
+        fill="none"
+        aria-hidden="true"
+      >
+        <circle cx={c} cy={c} r={r} stroke="currentColor" strokeOpacity="0.15" strokeWidth={stroke} />
+        <path
+          d={`M ${c} ${stroke / 2} A ${r} ${r} 0 0 1 ${c + r} ${c}`}
+          stroke="currentColor"
+          strokeWidth={stroke}
+          strokeLinecap="round"
+        />
+      </svg>
+    </span>
+  )
+}
+
+interface EmptyStateProps {
+  title: string
+  hint?: ReactNode
+  icon?: ReactNode
+  action?: ReactNode
+  className?: string
+  /** "margin" = the default library-margin feel. "panel" = vertically centered inside a panel. */
+  variant?: 'margin' | 'panel'
+}
+
+/**
+ * A quiet, bookish empty state. Reads like an annotation in the margin of
+ * an old book — never like a dashboard blank card. Title is a small serif
+ * italic line; optional hint teaches what the space is for.
+ */
+export function EmptyState({
+  title,
+  hint,
+  icon,
+  action,
+  className,
+  variant = 'margin',
+}: EmptyStateProps) {
+  return (
+    <div
+      className={cn(
+        'flex flex-col items-center text-center gap-2',
+        variant === 'panel' ? 'justify-center py-16' : 'py-10',
+        className,
+      )}
+      data-component-id="empty-state"
+    >
+      {icon
+        ? <span className="text-muted-foreground/40 mb-1">{icon}</span>
+        : <ErrataMark size={14} className="text-muted-foreground/30 mb-1" />
+      }
+      <p className="font-display italic text-[0.875rem] text-muted-foreground leading-snug">
+        {title}
+      </p>
+      {hint && (
+        <p className="text-[0.6875rem] text-muted-foreground/70 leading-relaxed max-w-[220px]">
+          {hint}
+        </p>
+      )}
+      {action && <div className="mt-2">{action}</div>}
+    </div>
+  )
+}
+

--- a/src/components/ui/file-drop-dialog.tsx
+++ b/src/components/ui/file-drop-dialog.tsx
@@ -1,0 +1,339 @@
+import * as React from 'react'
+import { cn } from '@/lib/utils'
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+} from '@/components/ui/dialog'
+import { Caption } from '@/components/ui/prose-text'
+import { AlertCircle } from 'lucide-react'
+
+/**
+ * A dialog shell for "drop a file, preview, confirm" flows.
+ *
+ * Visuals are tuned for Errata's bookish aesthetic — sliding a loose page
+ * into a book, not uploading to a SaaS. Reuses the shared
+ * `tavern-dropzone-dash` / `tavern-dropzone-glow` animations for motion.
+ *
+ * The scaffold is intentionally lean: callers supply the parsed preview,
+ * error text, and footer buttons. The standalone `<FileDropzone>` export
+ * can be used outside a dialog.
+ */
+
+// ── Dialog shell ──────────────────────────────────────────────────────
+
+type FileDropDialogProps = {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  title: React.ReactNode
+  description?: React.ReactNode
+  /** Applied to DialogContent. Callers typically set a max-width here. */
+  contentClassName?: string
+  /** Hides the built-in close button on DialogContent. Default: false (shown). */
+  showCloseButton?: boolean
+  children?: React.ReactNode
+}
+
+function FileDropDialogRoot({
+  open,
+  onOpenChange,
+  title,
+  description,
+  contentClassName,
+  showCloseButton = false,
+  children,
+}: FileDropDialogProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent
+        showCloseButton={showCloseButton}
+        className={cn(
+          'max-h-[85vh] flex flex-col overflow-hidden p-0 gap-0 border-border/60 bg-card',
+          contentClassName,
+        )}
+      >
+        <div className="px-6 pt-6 pb-4">
+          <p className="font-display text-xl tracking-tight">{title}</p>
+          {description && <Caption className="mt-1">{description}</Caption>}
+        </div>
+        <div className="flex-1 overflow-y-auto min-h-0 px-5 pb-4 flex flex-col gap-3">
+          {children}
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+// ── Dropzone (also exported standalone) ───────────────────────────────
+
+export type FileDropzoneProps = {
+  /** Called with one or more files from drop or picker. */
+  onFiles: (files: File[]) => void
+  /** Accepted file types, same syntax as `<input accept="…">`. */
+  accept?: string
+  /** Allow picking / dropping multiple files. Default: false. */
+  multiple?: boolean
+  /** Serif italic helper line under the title. */
+  hint?: React.ReactNode
+  /** Title line inside the drop zone. Default: "Drop a file, or click to pick one." */
+  label?: React.ReactNode
+  /** Optional icon rendered above the label. */
+  icon?: React.ReactNode
+  /** Disable drop + click (e.g. while parsing). */
+  disabled?: boolean
+  /** Force the "active drop" visual from the outside. */
+  forceActive?: boolean
+  /** Additional classes on the wrapper. */
+  className?: string
+  /** Slot rendered inside the zone instead of the default label stack. */
+  children?: React.ReactNode
+}
+
+/**
+ * A bookish drop-and-pick zone. Clickable, keyboard-accessible
+ * (Enter/Space opens the file picker). Uses the shared animated
+ * dashed border + primary glow when active.
+ */
+export const FileDropzone = React.forwardRef<HTMLDivElement, FileDropzoneProps>(
+  function FileDropzone(
+    {
+      onFiles,
+      accept,
+      multiple = false,
+      hint,
+      label = 'Drag a file here, or click to pick one.',
+      icon,
+      disabled = false,
+      forceActive = false,
+      className,
+      children,
+    },
+    ref,
+  ) {
+    const inputRef = React.useRef<HTMLInputElement>(null)
+    const [dragOver, setDragOver] = React.useState(false)
+    const active = forceActive || dragOver
+
+    const openPicker = React.useCallback(() => {
+      if (disabled) return
+      inputRef.current?.click()
+    }, [disabled])
+
+    const handleDrop = React.useCallback(
+      (e: React.DragEvent) => {
+        e.preventDefault()
+        e.stopPropagation()
+        setDragOver(false)
+        if (disabled) return
+        const files = Array.from(e.dataTransfer.files ?? [])
+        if (files.length > 0) onFiles(multiple ? files : [files[0]])
+      },
+      [onFiles, multiple, disabled],
+    )
+
+    const handleInput = React.useCallback(
+      (e: React.ChangeEvent<HTMLInputElement>) => {
+        const files = Array.from(e.target.files ?? [])
+        if (files.length > 0) onFiles(multiple ? files : [files[0]])
+        e.target.value = ''
+      },
+      [onFiles, multiple],
+    )
+
+    const handleKeyDown = React.useCallback(
+      (e: React.KeyboardEvent) => {
+        if (disabled) return
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault()
+          openPicker()
+        }
+      },
+      [openPicker, disabled],
+    )
+
+    return (
+      <div
+        ref={ref}
+        role="button"
+        tabIndex={disabled ? -1 : 0}
+        aria-disabled={disabled || undefined}
+        onClick={openPicker}
+        onKeyDown={handleKeyDown}
+        onDragOver={(e) => {
+          e.preventDefault()
+          if (!disabled) setDragOver(true)
+        }}
+        onDragLeave={() => setDragOver(false)}
+        onDrop={handleDrop}
+        className={cn(
+          'relative group rounded-xl overflow-hidden transition-all duration-300 outline-none',
+          'focus-visible:ring-2 focus-visible:ring-ring/40 focus-visible:ring-offset-2 focus-visible:ring-offset-background',
+          disabled ? 'opacity-60 cursor-not-allowed' : 'cursor-pointer',
+          active ? 'scale-[0.98]' : !disabled && 'hover:scale-[0.995]',
+          className,
+        )}
+      >
+        {/* Animated dashed border (reuses the tavern dropzone keyframes) */}
+        <svg
+          className="absolute inset-0 w-full h-full pointer-events-none"
+          preserveAspectRatio="none"
+          aria-hidden="true"
+        >
+          <rect
+            x="1"
+            y="1"
+            width="calc(100% - 2px)"
+            height="calc(100% - 2px)"
+            rx="11"
+            ry="11"
+            fill="none"
+            className={cn(
+              'transition-all duration-300',
+              active
+                ? 'stroke-primary/50'
+                : 'stroke-border/60 group-hover:stroke-border',
+            )}
+            strokeWidth="1.5"
+            strokeDasharray="6 6"
+            style={{ animation: 'tavern-dropzone-dash 1.5s linear infinite' }}
+          />
+        </svg>
+
+        <div
+          className={cn(
+            'relative flex flex-col items-center justify-center py-12 px-8 transition-colors duration-300',
+            active ? 'bg-primary/[0.04]' : 'bg-muted/30',
+          )}
+        >
+          {children ?? (
+            <>
+              {icon && (
+                <div
+                  className={cn(
+                    'relative mb-4 transition-all duration-300',
+                    active ? 'scale-110' : 'group-hover:scale-105',
+                  )}
+                >
+                  <div
+                    className={cn(
+                      'w-14 h-16 rounded-lg bg-gradient-to-b from-muted-foreground/[0.07] to-muted-foreground/[0.03] flex items-center justify-center overflow-hidden transition-colors duration-300',
+                      active ? 'text-primary/40' : 'text-muted-foreground',
+                    )}
+                  >
+                    {icon}
+                  </div>
+                  {active && (
+                    <div
+                      className="absolute -inset-3 rounded-2xl bg-primary/10 blur-lg"
+                      style={{ animation: 'tavern-dropzone-glow 2s ease-in-out infinite' }}
+                      aria-hidden="true"
+                    />
+                  )}
+                </div>
+              )}
+              <p
+                className={cn(
+                  'font-display italic text-sm tracking-tight transition-colors duration-200',
+                  active ? 'text-primary' : 'text-foreground/70 group-hover:text-foreground/80',
+                )}
+              >
+                {label}
+              </p>
+              {hint && (
+                <p className="text-[0.6875rem] text-muted-foreground mt-1.5 text-center">
+                  {hint}
+                </p>
+              )}
+            </>
+          )}
+        </div>
+
+        <input
+          ref={inputRef}
+          type="file"
+          accept={accept}
+          multiple={multiple}
+          className="hidden"
+          onChange={handleInput}
+          tabIndex={-1}
+        />
+      </div>
+    )
+  },
+)
+
+// ── Compound slots ────────────────────────────────────────────────────
+
+function FileDropDialogDropzone(props: FileDropzoneProps) {
+  return <FileDropzone {...props} />
+}
+
+function FileDropDialogPreview({
+  children,
+  className,
+}: {
+  children: React.ReactNode
+  className?: string
+}) {
+  // Intentionally flat — no card frame. Consumers wrap their own container
+  // if the preview needs one (e.g. a selectable grid).
+  return <div className={cn('flex flex-col gap-2 min-h-0', className)}>{children}</div>
+}
+
+function FileDropDialogErrors({
+  children,
+  className,
+}: {
+  children?: React.ReactNode
+  className?: string
+}) {
+  if (!children) return null
+  return (
+    <div
+      role="alert"
+      className={cn(
+        'flex items-start gap-2 text-xs text-destructive/80 bg-destructive/5 rounded-lg px-3 py-2.5',
+        className,
+      )}
+    >
+      <AlertCircle className="size-3.5 mt-0.5 shrink-0" aria-hidden="true" />
+      <span>{children}</span>
+    </div>
+  )
+}
+
+function FileDropDialogActions({
+  children,
+  meta,
+  className,
+}: {
+  children: React.ReactNode
+  /** Left-aligned meta (e.g. "3 of 7 selected") sitting on the same row. */
+  meta?: React.ReactNode
+  className?: string
+}) {
+  return (
+    <>
+      <div className="px-6">
+        <div className="h-px bg-gradient-to-r from-transparent via-border/60 to-transparent" />
+      </div>
+      <DialogFooter className={cn('px-5 py-3.5 flex-row items-center', className)}>
+        {meta && (
+          <span className="text-[0.6875rem] text-muted-foreground mr-auto tabular-nums">
+            {meta}
+          </span>
+        )}
+        {children}
+      </DialogFooter>
+    </>
+  )
+}
+
+// ── Public compound API ───────────────────────────────────────────────
+
+export const FileDropDialog = Object.assign(FileDropDialogRoot, {
+  Dropzone: FileDropDialogDropzone,
+  Preview: FileDropDialogPreview,
+  Errors: FileDropDialogErrors,
+  Actions: FileDropDialogActions,
+})

--- a/src/components/ui/panel.tsx
+++ b/src/components/ui/panel.tsx
@@ -1,0 +1,144 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+import { Spinner } from "@/components/ui/async-view"
+import { Caption } from "@/components/ui/prose-text"
+
+/**
+ * Panel — the side-drawer scaffold.
+ *
+ * Panels live inside a sheet/drawer/column that already scopes width and
+ * background. The scaffold provides the vertical rhythm: a breathable
+ * serif-titled header, a scrolling body, an optional sticky footer.
+ *
+ * Compose with the standard shadcn pattern:
+ *
+ *   <Panel>
+ *     <PanelHeader>
+ *       <PanelTitle>…</PanelTitle>
+ *       <PanelDescription>…</PanelDescription>
+ *       <PanelActions>…</PanelActions>
+ *     </PanelHeader>
+ *     <PanelBody>…</PanelBody>
+ *     <PanelFooter>…</PanelFooter>
+ *   </Panel>
+ */
+
+function Panel({
+  className,
+  loading,
+  children,
+  ...props
+}: React.ComponentProps<"div"> & { loading?: boolean }) {
+  return (
+    <div
+      data-slot="panel"
+      className={cn("flex h-full min-h-0 flex-col", className)}
+      {...props}
+    >
+      {loading ? (
+        <div className="flex flex-1 items-center justify-center">
+          <Spinner />
+        </div>
+      ) : (
+        children
+      )}
+    </div>
+  )
+}
+
+function PanelHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="panel-header"
+      className={cn(
+        "shrink-0 flex items-center justify-between gap-4 px-5 py-5 border-b border-border/60",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function PanelHeaderText({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="panel-header-text"
+      className={cn("min-w-0 flex-1 flex flex-col gap-1", className)}
+      {...props}
+    />
+  )
+}
+
+function PanelTitle({ className, ...props }: React.ComponentProps<"h2">) {
+  return (
+    <h2
+      data-slot="panel-title"
+      className={cn(
+        "font-display font-normal text-lg leading-tight tracking-tight truncate",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function PanelDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof Caption>) {
+  return (
+    <Caption
+      data-slot="panel-description"
+      className={cn("text-xs leading-snug", className)}
+      {...props}
+    />
+  )
+}
+
+function PanelActions({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="panel-actions"
+      className={cn("shrink-0 flex items-center gap-1.5", className)}
+      {...props}
+    />
+  )
+}
+
+function PanelBody({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="panel-body"
+      className={cn(
+        "flex-1 min-h-0 overflow-y-auto px-5 py-4 flex flex-col gap-4",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function PanelFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="panel-footer"
+      className={cn(
+        "shrink-0 flex items-center gap-2 px-5 py-3 border-t border-border/60",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export {
+  Panel,
+  PanelHeader,
+  PanelHeaderText,
+  PanelTitle,
+  PanelDescription,
+  PanelActions,
+  PanelBody,
+  PanelFooter,
+}

--- a/src/components/ui/prose-text.tsx
+++ b/src/components/ui/prose-text.tsx
@@ -1,0 +1,86 @@
+import * as React from "react"
+import { Slot } from "radix-ui"
+import { cn } from "@/lib/utils"
+
+type AsChildProps = { asChild?: boolean }
+
+export type HintProps = React.HTMLAttributes<HTMLParagraphElement> &
+  AsChildProps & {
+    size?: "xs" | "sm"
+  }
+
+export const Hint = React.forwardRef<HTMLParagraphElement, HintProps>(
+  function Hint({ asChild, size = "xs", className, ...props }, ref) {
+    const Comp = asChild ? Slot.Root : "p"
+    return (
+      <Comp
+        ref={ref}
+        className={cn(
+          size === "sm" ? "text-sm" : "text-xs",
+          "text-muted-foreground",
+          className
+        )}
+        {...props}
+      />
+    )
+  }
+)
+
+export type CaptionProps = React.HTMLAttributes<HTMLParagraphElement> &
+  AsChildProps & {
+    size?: "xs" | "sm"
+  }
+
+export const Caption = React.forwardRef<HTMLParagraphElement, CaptionProps>(
+  function Caption({ asChild, size = "xs", className, ...props }, ref) {
+    const Comp = asChild ? Slot.Root : "p"
+    return (
+      <Comp
+        ref={ref}
+        className={cn(
+          size === "sm" ? "text-sm" : "text-xs",
+          "font-prose leading-relaxed text-muted-foreground",
+          className
+        )}
+        {...props}
+      />
+    )
+  }
+)
+
+export type MetaLabelProps = React.HTMLAttributes<HTMLSpanElement> & AsChildProps
+
+export const MetaLabel = React.forwardRef<HTMLSpanElement, MetaLabelProps>(
+  function MetaLabel({ asChild, className, ...props }, ref) {
+    const Comp = asChild ? Slot.Root : "span"
+    return (
+      <Comp
+        ref={ref}
+        className={cn("text-xs text-muted-foreground", className)}
+        {...props}
+      />
+    )
+  }
+)
+
+export type EmptyHintProps = React.HTMLAttributes<HTMLParagraphElement> &
+  AsChildProps & {
+    size?: "xs" | "sm"
+  }
+
+export const EmptyHint = React.forwardRef<HTMLParagraphElement, EmptyHintProps>(
+  function EmptyHint({ asChild, size = "xs", className, ...props }, ref) {
+    const Comp = asChild ? Slot.Root : "p"
+    return (
+      <Comp
+        ref={ref}
+        className={cn(
+          size === "sm" ? "text-sm" : "text-xs",
+          "italic text-muted-foreground",
+          className
+        )}
+        {...props}
+      />
+    )
+  }
+)

--- a/src/components/ui/wizard.tsx
+++ b/src/components/ui/wizard.tsx
@@ -1,0 +1,567 @@
+import * as React from 'react'
+import { ChevronLeft, ChevronRight } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import { Button } from '@/components/ui/button'
+import { Caption } from '@/components/ui/prose-text'
+
+/**
+ * Wizard scaffold.
+ *
+ * A compound component for multi-step flows (story setup, onboarding). Provides
+ * the shared skeleton — step transition, header (serif title + caption), body,
+ * footer with back/next — while leaving step-specific content untouched.
+ *
+ * The typographic feel is bookish: chapter-heading titles in the display serif,
+ * Roman-numeral page counts (iii / vii), no percent bars, no stepper dots with
+ * check-marks. Transition uses the existing `animate-wizard-step-enter`; under
+ * `prefers-reduced-motion` it collapses to `animate-onboarding-fade-in` (pure
+ * opacity fade).
+ *
+ * Keyboard:
+ *  - Enter            → advance, when the current step passes `canAdvance`
+ *  - Escape           → invoke `onClose`, if provided
+ *  - Left/Right arrow → intentionally NOT bound (text inputs own them)
+ */
+
+// ── Context ────────────────────────────────────────────
+
+interface WizardContextValue {
+  /** Stable key of the active step. */
+  stepKey: string
+  /** 0-based index of the active step; -1 if unknown. */
+  stepIndex: number
+  /** Total step count shown in progress indicator. May exclude terminal steps. */
+  total: number
+  /** Close handler, exposed for Escape-driven exits. */
+  onClose?: () => void
+  /** Set by Wizard.Step so the scaffold knows the current step's key. */
+  setActiveStepKey: (key: string, index: number) => void
+}
+
+const WizardContext = React.createContext<WizardContextValue | null>(null)
+
+function useWizardContext() {
+  const ctx = React.useContext(WizardContext)
+  if (!ctx) throw new Error('Wizard.* must be used inside <Wizard>.')
+  return ctx
+}
+
+// ── Root ───────────────────────────────────────────────
+
+export interface WizardProps {
+  /** Key of the currently-visible step. Must match a `<Wizard.Step stepKey>`. */
+  step: string
+  /** Total steps shown in the progress indicator. Defaults to children count. */
+  total?: number
+  /**
+   * Fallback Enter-key advance handler. Normally not needed — `<Wizard.NextButton>`
+   * registers its own and that is what Enter invokes. Use this only if a step
+   * wants Enter to advance without a visible NextButton.
+   */
+  onAdvance?: () => void
+  /** Escape-key close. If omitted, Escape does nothing. */
+  onClose?: () => void
+  className?: string
+  children: React.ReactNode
+}
+
+export function Wizard({
+  step,
+  total,
+  onAdvance,
+  onClose,
+  className,
+  children,
+}: WizardProps) {
+  const [active, setActive] = React.useState<{ key: string; index: number }>({
+    key: step,
+    index: -1,
+  })
+  const [canAdvance, setCanAdvance] = React.useState(false)
+  // NextButton registers its onAdvance here so Enter invokes the same fn.
+  const buttonAdvanceRef = React.useRef<(() => void) | undefined>(undefined)
+  const setAdvanceHandler = React.useCallback((fn: (() => void) | undefined) => {
+    buttonAdvanceRef.current = fn
+  }, [])
+  const rootAdvanceRef = React.useRef<(() => void) | undefined>(onAdvance)
+  const closeRef = React.useRef<(() => void) | undefined>(onClose)
+
+  rootAdvanceRef.current = onAdvance
+  closeRef.current = onClose
+
+  // Count declared steps for default total.
+  const declaredTotal = React.useMemo(() => {
+    let n = 0
+    React.Children.forEach(children, (child) => {
+      if (React.isValidElement(child) && (child.type as { __wizardStep?: boolean })?.__wizardStep) {
+        n++
+      }
+    })
+    return n
+  }, [children])
+
+  const setActiveStepKey = React.useCallback((key: string, index: number) => {
+    setActive((prev) => (prev.key === key && prev.index === index ? prev : { key, index }))
+  }, [])
+
+  // Keyboard: Enter (advance), Escape (close). Left/Right intentionally unbound.
+  React.useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') {
+        if (closeRef.current) {
+          e.preventDefault()
+          closeRef.current()
+        }
+        return
+      }
+      if (e.key === 'Enter') {
+        // Don't hijack Enter inside multi-line inputs or when a button has focus.
+        const target = e.target as HTMLElement | null
+        if (target) {
+          const tag = target.tagName
+          if (tag === 'TEXTAREA') return
+          if (tag === 'BUTTON') return
+          // Respect contentEditable surfaces (prose editor, etc).
+          if (target.isContentEditable) return
+        }
+        if (canAdvance) {
+          const fn = buttonAdvanceRef.current ?? rootAdvanceRef.current
+          if (fn) {
+            e.preventDefault()
+            fn()
+          }
+        }
+      }
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [canAdvance])
+
+  const value = React.useMemo<WizardContextValue>(
+    () => ({
+      stepKey: active.key,
+      stepIndex: active.index,
+      total: total ?? declaredTotal,
+      onClose,
+      setActiveStepKey,
+    }),
+    [active.key, active.index, total, declaredTotal, onClose, setActiveStepKey],
+  )
+
+  // Expose a setter for Step children via a nested provider below.
+  return (
+    <WizardContext.Provider value={value}>
+      <WizardAdvanceRegistration setCanAdvance={setCanAdvance} setAdvanceHandler={setAdvanceHandler}>
+        <div className={cn('flex flex-col h-full', className)} data-component-id="wizard-root">
+          {React.Children.map(children, (child) => {
+            if (!React.isValidElement(child)) return child
+            const type = child.type as { __wizardStep?: boolean }
+            if (type?.__wizardStep) {
+              const stepKey = (child as React.ReactElement<{ stepKey?: string }>).props.stepKey
+              const key = stepKey ?? (child.key ? String(child.key) : '')
+              if (!key) {
+                // Surface the misconfiguration early.
+                if (typeof console !== 'undefined') {
+                  console.warn('<Wizard.Step> requires a `key` or `stepKey` prop.')
+                }
+              }
+              return key === step ? child : null
+            }
+            return child
+          })}
+        </div>
+      </WizardAdvanceRegistration>
+    </WizardContext.Provider>
+  )
+}
+
+// ── canAdvance plumbing ────────────────────────────────
+//
+// NextButton registers a handler + its `disabled` state. Enter-to-advance then
+// invokes the same function the button does. Kept in its own tiny context to
+// avoid re-rendering the whole wizard on every keystroke.
+
+const AdvanceRegistrationContext = React.createContext<{
+  setCanAdvance: (v: boolean) => void
+  setAdvanceHandler: (fn: (() => void) | undefined) => void
+} | null>(null)
+
+function WizardAdvanceRegistration({
+  setCanAdvance,
+  setAdvanceHandler,
+  children,
+}: {
+  setCanAdvance: (v: boolean) => void
+  setAdvanceHandler: (fn: (() => void) | undefined) => void
+  children: React.ReactNode
+}) {
+  const value = React.useMemo(
+    () => ({ setCanAdvance, setAdvanceHandler }),
+    [setCanAdvance, setAdvanceHandler],
+  )
+  return (
+    <AdvanceRegistrationContext.Provider value={value}>{children}</AdvanceRegistrationContext.Provider>
+  )
+}
+
+// ── Step ───────────────────────────────────────────────
+
+export interface WizardStepProps {
+  /** Unique key matching the parent Wizard's `step` prop. */
+  stepKey?: string
+  /** 1-based index shown in the progress indicator. Falls back to auto-counting. */
+  stepIndex?: number
+  /** Hide the progress indicator entirely for this step (e.g. welcome, completion). */
+  hideProgress?: boolean
+  /**
+   * How the step's contents should animate in.
+   *  - `slide` (default): `wizard-step-enter` — a short translateY slide-up.
+   *  - `fade`: `onboarding-fade-in` — opacity only. Use when the step already
+   *     owns a rich staggered entrance (onboarding vignettes).
+   *  - `none`: no wrapper animation.
+   */
+  transition?: 'slide' | 'fade' | 'none'
+  className?: string
+  children: React.ReactNode
+}
+
+function WizardStep({
+  stepKey,
+  stepIndex,
+  hideProgress,
+  transition = 'slide',
+  className,
+  children,
+}: WizardStepProps) {
+  const ctx = useWizardContext()
+  React.useEffect(() => {
+    if (stepKey) ctx.setActiveStepKey(stepKey, stepIndex ?? -1)
+  }, [stepKey, stepIndex, ctx])
+
+  const animation =
+    transition === 'slide'
+      ? 'motion-safe:animate-wizard-step-enter motion-reduce:animate-onboarding-fade-in'
+      : transition === 'fade'
+        ? 'animate-onboarding-fade-in'
+        : ''
+
+  return (
+    <div
+      key={stepKey ?? 'step'}
+      className={cn(animation, 'flex flex-col min-h-0 flex-1', className)}
+      data-wizard-step={stepKey}
+      data-hide-progress={hideProgress ? '' : undefined}
+    >
+      {children}
+    </div>
+  )
+}
+
+;(WizardStep as unknown as { __wizardStep: boolean }).__wizardStep = true
+
+// ── Header / Title / Description ───────────────────────
+
+export interface WizardStepHeaderProps extends React.HTMLAttributes<HTMLDivElement> {}
+
+function WizardStepHeader({ className, ...props }: WizardStepHeaderProps) {
+  return <div className={cn('mb-8', className)} {...props} />
+}
+
+export interface WizardStepTitleProps extends React.HTMLAttributes<HTMLHeadingElement> {
+  /** Display size. Onboarding uses `hero`, normal steps use `default`. */
+  size?: 'default' | 'hero'
+}
+
+function WizardStepTitle({ size = 'default', className, ...props }: WizardStepTitleProps) {
+  return (
+    <h2
+      className={cn(
+        'font-display italic leading-tight',
+        size === 'hero' ? 'text-3xl sm:text-4xl' : 'text-2xl sm:text-3xl',
+        className,
+      )}
+      {...props}
+    />
+  )
+}
+
+export interface WizardStepDescriptionProps extends React.ComponentProps<typeof Caption> {}
+
+function WizardStepDescription({ className, size = 'sm', ...props }: WizardStepDescriptionProps) {
+  return <Caption size={size} className={cn('mt-2', className)} {...props} />
+}
+
+// ── Body ───────────────────────────────────────────────
+
+export interface WizardStepBodyProps extends React.HTMLAttributes<HTMLDivElement> {
+  /**
+   * Scroll container width. Most steps use `narrow` (`max-w-xl`); onboarding
+   * provider-select uses `wide` (`max-w-2xl`). Pass `none` to opt out entirely.
+   */
+  width?: 'narrow' | 'wide' | 'none'
+  /** Give the body its own scroll instead of inheriting page scroll. */
+  scroll?: boolean
+}
+
+function WizardStepBody({
+  width = 'narrow',
+  scroll = true,
+  className,
+  ...props
+}: WizardStepBodyProps) {
+  return (
+    <div
+      className={cn(scroll ? 'flex-1 overflow-auto' : undefined)}
+      data-component-id="wizard-step-body"
+    >
+      <div
+        className={cn(
+          width === 'narrow' && 'max-w-xl mx-auto px-5 py-4 sm:px-8 sm:py-8',
+          width === 'wide' && 'max-w-2xl mx-auto px-5 py-4 sm:px-8 sm:py-8',
+          className,
+        )}
+        {...props}
+      />
+    </div>
+  )
+}
+
+// ── Footer ─────────────────────────────────────────────
+
+export interface WizardStepFooterProps extends React.HTMLAttributes<HTMLDivElement> {
+  /** `divided` adds a hairline border above the footer; `clean` omits it. */
+  variant?: 'divided' | 'clean'
+  /** Layout: `spread` pushes back/next to edges; `center` centers everything. */
+  align?: 'spread' | 'center'
+}
+
+function WizardStepFooter({
+  variant = 'divided',
+  align = 'spread',
+  className,
+  children,
+  ...props
+}: WizardStepFooterProps) {
+  return (
+    <div
+      className={cn(
+        'mt-10 pt-4 flex items-center gap-2',
+        variant === 'divided' && 'border-t border-border/20',
+        align === 'spread' ? 'justify-between' : 'justify-center',
+        className,
+      )}
+      {...props}
+    >
+      {children}
+    </div>
+  )
+}
+
+// ── Back / Next buttons ────────────────────────────────
+
+export interface WizardBackButtonProps extends React.ComponentProps<typeof Button> {
+  /** Called when the button is clicked. */
+  onBack?: () => void
+  /** Shown next to the chevron. Defaults to `Back`. */
+  children?: React.ReactNode
+  /** Render a ghost button (default) or a quieter plain link. */
+  tone?: 'ghost' | 'link'
+}
+
+function WizardBackButton({
+  onBack,
+  onClick,
+  children = 'Back',
+  tone = 'ghost',
+  className,
+  ...props
+}: WizardBackButtonProps) {
+  const handle = (e: React.MouseEvent<HTMLButtonElement>) => {
+    onClick?.(e)
+    if (!e.defaultPrevented) onBack?.()
+  }
+
+  if (tone === 'link') {
+    return (
+      <button
+        onClick={handle}
+        className={cn(
+          'text-xs text-muted-foreground hover:text-foreground transition-colors flex items-center gap-1',
+          className,
+        )}
+        {...(props as React.ButtonHTMLAttributes<HTMLButtonElement>)}
+      >
+        <ChevronLeft className="size-3" /> {children}
+      </button>
+    )
+  }
+
+  return (
+    <Button
+      variant="ghost"
+      size="sm"
+      className={cn('gap-1.5 text-muted-foreground', className)}
+      onClick={handle}
+      {...props}
+    >
+      <ChevronLeft className="size-3.5" /> {children}
+    </Button>
+  )
+}
+
+export interface WizardNextButtonProps extends React.ComponentProps<typeof Button> {
+  /** Called when the button is clicked or Enter is pressed. */
+  onAdvance?: () => void
+  /** Button label. Falls back to `Continue`. */
+  children?: React.ReactNode
+  /** Show the chevron glyph. Defaults to `true`. */
+  withChevron?: boolean
+}
+
+function WizardNextButton({
+  onAdvance,
+  onClick,
+  children = 'Continue',
+  withChevron = true,
+  disabled,
+  className,
+  ...props
+}: WizardNextButtonProps) {
+  const reg = React.useContext(AdvanceRegistrationContext)
+
+  // Tell the Wizard root whether Enter should advance, and wire the button's
+  // handler so Enter and click invoke the same function.
+  React.useEffect(() => {
+    if (!reg) return
+    reg.setCanAdvance(!disabled)
+    reg.setAdvanceHandler(disabled ? undefined : onAdvance)
+    return () => {
+      reg.setCanAdvance(false)
+      reg.setAdvanceHandler(undefined)
+    }
+  }, [reg, disabled, onAdvance])
+
+  const handle = (e: React.MouseEvent<HTMLButtonElement>) => {
+    onClick?.(e)
+    if (!e.defaultPrevented) onAdvance?.()
+  }
+
+  return (
+    <Button size="sm" className={cn('gap-1.5', className)} disabled={disabled} onClick={handle} {...props}>
+      {children}
+      {withChevron && <ChevronRight className="size-3.5" />}
+    </Button>
+  )
+}
+
+// ── Skip ───────────────────────────────────────────────
+
+export interface WizardSkipButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  /** Label. Defaults to `Skip setup`. */
+  children?: React.ReactNode
+}
+
+function WizardSkipButton({ className, children = 'Skip setup', ...props }: WizardSkipButtonProps) {
+  return (
+    <button
+      className={cn(
+        'text-[0.6875rem] text-muted-foreground hover:text-foreground transition-colors',
+        className,
+      )}
+      {...props}
+    >
+      {children}
+    </button>
+  )
+}
+
+// ── Progress ───────────────────────────────────────────
+
+export interface WizardProgressProps {
+  /** Current step index (1-based). Falls back to active step context. */
+  current?: number
+  /** Total steps. Falls back to context `total`. */
+  total?: number
+  className?: string
+}
+
+const ROMAN: Record<number, string> = {
+  1: 'i',
+  2: 'ii',
+  3: 'iii',
+  4: 'iv',
+  5: 'v',
+  6: 'vi',
+  7: 'vii',
+  8: 'viii',
+  9: 'ix',
+  10: 'x',
+  11: 'xi',
+  12: 'xii',
+}
+
+function toRoman(n: number): string {
+  if (ROMAN[n]) return ROMAN[n]
+  // Fallback: arabic. The wizard never has more than a dozen steps in practice.
+  return String(n)
+}
+
+/**
+ * Page-count progress indicator: a pair of lowercase Roman numerals in the
+ * display serif, separated by a thin slash — like the front-matter pagination
+ * of a printed book. No bars, no dots, no percents.
+ */
+function WizardProgress({ current, total, className }: WizardProgressProps) {
+  const ctx = useWizardContext()
+  const resolvedCurrent = current ?? (ctx.stepIndex >= 0 ? ctx.stepIndex + 1 : undefined)
+  const resolvedTotal = total ?? ctx.total
+  if (!resolvedCurrent || !resolvedTotal) return null
+  return (
+    <span
+      className={cn(
+        'font-display italic text-[0.8125rem] text-muted-foreground/70 tabular-nums tracking-wide',
+        className,
+      )}
+      aria-label={`Step ${resolvedCurrent} of ${resolvedTotal}`}
+    >
+      {toRoman(resolvedCurrent)}
+      <span className="mx-1 text-muted-foreground/40">/</span>
+      {toRoman(resolvedTotal)}
+    </span>
+  )
+}
+
+// ── Toolbar ────────────────────────────────────────────
+//
+// A thin top strip holding progress on the left and skip on the right, mirroring
+// the existing StoryWizard shell. Optional — steps may omit it or roll their own.
+
+export interface WizardToolbarProps extends React.HTMLAttributes<HTMLDivElement> {}
+
+function WizardToolbar({ className, children, ...props }: WizardToolbarProps) {
+  return (
+    <div
+      className={cn(
+        'flex items-center justify-between px-6 py-3 border-b border-border/15',
+        className,
+      )}
+      {...props}
+    >
+      {children}
+    </div>
+  )
+}
+
+// ── Compound exports ───────────────────────────────────
+
+Wizard.Step = WizardStep as React.FC<WizardStepProps>
+Wizard.StepHeader = WizardStepHeader
+Wizard.StepTitle = WizardStepTitle
+Wizard.StepDescription = WizardStepDescription
+Wizard.StepBody = WizardStepBody
+Wizard.StepFooter = WizardStepFooter
+Wizard.BackButton = WizardBackButton
+Wizard.NextButton = WizardNextButton
+Wizard.SkipButton = WizardSkipButton
+Wizard.Progress = WizardProgress
+Wizard.Toolbar = WizardToolbar

--- a/src/components/wizard/StoryWizard.tsx
+++ b/src/components/wizard/StoryWizard.tsx
@@ -5,10 +5,12 @@ import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Textarea } from '@/components/ui/textarea'
 import {
-  Sparkles, Square, ChevronLeft, ChevronRight,
+  Sparkles, Square,
   Plus, Trash2, Check, Pen, Bot, Users, PenLine,
   RefreshCw, BookOpen, Layers, Eye, Zap,
 } from 'lucide-react'
+import { Hint, Caption, EmptyHint } from '@/components/ui/prose-text'
+import { Wizard } from '@/components/ui/wizard'
 
 // ── Types ──────────────────────────────────────────────
 
@@ -18,8 +20,6 @@ interface StoryWizardProps {
 }
 
 type WizardStep = 'concept' | 'guideline' | 'world' | 'characters' | 'preferences' | 'prose' | 'complete'
-
-const STEPS: WizardStep[] = ['concept', 'guideline', 'world', 'characters', 'preferences', 'prose', 'complete']
 
 const STEP_QUESTIONS: Record<WizardStep, { question: string; subtitle: string }> = {
   concept:     { question: 'Begin your story',            subtitle: 'Give it a name and a spark of inspiration.' },
@@ -91,64 +91,30 @@ function useGenerate(storyId: string) {
   return { text, setText, isStreaming, error, generate, stop, clear }
 }
 
-// ── WizardShell ──────────────────────────────────────────
+// ── StepShell ─────────────────────────────────────────
+//
+// Header + body composition shared by every story-wizard step. The surrounding
+// <Wizard.Step> in the root handles transition and key switching.
 
-function WizardShell({
+/** How many steps we count toward the progress indicator (excludes concept + complete). */
+const COUNTED_STEPS: WizardStep[] = ['guideline', 'world', 'characters', 'preferences', 'prose']
+
+function StepShell({
   step,
-  onSkip,
   children,
 }: {
   step: WizardStep
-  onSkip: () => void
   children: React.ReactNode
 }) {
-  const stepIndex = STEPS.indexOf(step)
-  const progress = stepIndex / (STEPS.length - 1)
   const q = STEP_QUESTIONS[step]
-  const showStepCount = step !== 'concept' && step !== 'complete'
-
   return (
-    <div className="flex flex-col h-full" data-component-id="wizard-root">
-      {/* Progress bar */}
-      <div className="h-0.5 bg-border/20">
-        <div
-          className="h-full bg-primary/50 transition-all duration-500 ease-out"
-          style={{ width: `${progress * 100}%` }}
-        />
-      </div>
-
-      {/* Header */}
-      <div className="flex items-center justify-between px-6 py-3">
-        <span className="text-[0.625rem] text-muted-foreground uppercase tracking-widest">
-          {showStepCount ? `Step ${stepIndex} of ${STEPS.length - 2}` : '\u00a0'}
-        </span>
-        <button
-          onClick={onSkip}
-          className="text-[0.6875rem] text-muted-foreground hover:text-muted-foreground transition-colors"
-          data-component-id="wizard-skip"
-        >
-          Skip setup
-        </button>
-      </div>
-
-      {/* Content */}
-      <div className="flex-1 overflow-auto" key={step}>
-        <div className="animate-wizard-step-enter max-w-xl mx-auto px-5 py-4 sm:px-8 sm:py-8">
-          {/* Question heading */}
-          <div className="mb-8">
-            <h2 className="font-display text-2xl sm:text-3xl italic leading-tight">
-              {q.question}
-            </h2>
-            {q.subtitle && (
-              <p className="font-prose text-sm text-muted-foreground mt-2 leading-relaxed">
-                {q.subtitle}
-              </p>
-            )}
-          </div>
-          {children}
-        </div>
-      </div>
-    </div>
+    <Wizard.StepBody width="narrow">
+      <Wizard.StepHeader>
+        <Wizard.StepTitle>{q.question}</Wizard.StepTitle>
+        {q.subtitle && <Wizard.StepDescription>{q.subtitle}</Wizard.StepDescription>}
+      </Wizard.StepHeader>
+      {children}
+    </Wizard.StepBody>
   )
 }
 
@@ -251,26 +217,14 @@ function StepNav({
   showBack?: boolean
 }) {
   return (
-    <div className="flex items-center justify-between mt-10 pt-4 border-t border-border/20">
+    <Wizard.StepFooter>
       {showBack && onBack ? (
-        <Button
-          variant="ghost"
-          size="sm"
-          className="gap-1.5 text-muted-foreground"
-          onClick={onBack}
-        >
-          <ChevronLeft className="size-3.5" /> Back
-        </Button>
+        <Wizard.BackButton onBack={onBack} />
       ) : <div />}
-      <Button
-        size="sm"
-        className="gap-1.5"
-        onClick={onContinue}
-        disabled={!canContinue}
-      >
-        {continueLabel} <ChevronRight className="size-3.5" />
-      </Button>
-    </div>
+      <Wizard.NextButton onAdvance={onContinue} disabled={!canContinue}>
+        {continueLabel}
+      </Wizard.NextButton>
+    </Wizard.StepFooter>
   )
 }
 
@@ -283,7 +237,6 @@ function ConceptStep({
   storyDesc,
   setStoryDesc,
   onContinue,
-  onSkip,
 }: {
   storyId: string
   storyName: string
@@ -291,7 +244,6 @@ function ConceptStep({
   storyDesc: string
   setStoryDesc: (v: string) => void
   onContinue: () => void
-  onSkip: () => void
 }) {
   const queryClient = useQueryClient()
   const [saving, setSaving] = useState(false)
@@ -335,7 +287,7 @@ function ConceptStep({
   }
 
   return (
-    <WizardShell step="concept" onSkip={onSkip}>
+    <StepShell step="concept">
       <div className="space-y-6">
         <div>
           <Input
@@ -347,9 +299,11 @@ function ConceptStep({
         </div>
 
         <div>
-          <label className="text-xs text-muted-foreground mb-2 block font-prose">
-            A theme, a world, a feeling &mdash; this guides AI generation throughout.
-          </label>
+          <Hint asChild className="mb-2 block font-prose">
+            <label>
+              A theme, a world, a feeling &mdash; this guides AI generation throughout.
+            </label>
+          </Hint>
           <Textarea
             value={storyDesc}
             onChange={e => setStoryDesc(e.target.value)}
@@ -360,9 +314,11 @@ function ConceptStep({
 
         {showProviderPicker && globalConfig && (
           <div>
-            <label className="text-xs text-muted-foreground mb-2 block font-prose">
-              Model provider for generation
-            </label>
+            <Hint asChild className="mb-2 block font-prose">
+              <label>
+                Model provider for generation
+              </label>
+            </Hint>
             <div className="flex items-center gap-2 p-2.5 rounded-xl border border-border/40 bg-card/30">
               <Bot className="size-4 text-muted-foreground shrink-0" />
               <select
@@ -411,7 +367,7 @@ function ConceptStep({
         canContinue={!saving}
         showBack={false}
       />
-    </WizardShell>
+    </StepShell>
   )
 }
 
@@ -427,7 +383,6 @@ function ContentStep({
   fragmentId,
   onContinue,
   onBack,
-  onSkip,
   onSaved,
   storyDesc,
 }: {
@@ -438,7 +393,6 @@ function ContentStep({
   fragmentId: string | null
   onContinue: () => void
   onBack: () => void
-  onSkip: () => void
   onSaved: (id: string) => void
   storyDesc: string
 }) {
@@ -561,7 +515,7 @@ function ContentStep({
   const charLimit = step === 'guideline' ? { min: 500, max: 2000 } : undefined
 
   return (
-    <WizardShell step={step} onSkip={onSkip}>
+    <StepShell step={step}>
       {/* Phase: Choose */}
       {phase === 'choose' && (
         <div className="space-y-3">
@@ -572,9 +526,9 @@ function ContentStep({
             >
               <Sparkles className="size-5 text-primary/60 mb-3" />
               <div className="font-display text-base italic">Generate</div>
-              <p className="text-xs text-muted-foreground mt-1 leading-relaxed">
+              <Hint className="mt-1 leading-relaxed">
                 Let AI create it based on your story concept
-              </p>
+              </Hint>
             </button>
             <button
               onClick={() => setPhase('write')}
@@ -582,9 +536,9 @@ function ContentStep({
             >
               <PenLine className="size-5 text-muted-foreground mb-3" />
               <div className="font-display text-base italic">Write</div>
-              <p className="text-xs text-muted-foreground mt-1 leading-relaxed">
+              <Hint className="mt-1 leading-relaxed">
                 Write it yourself from scratch
-              </p>
+              </Hint>
             </button>
           </div>
         </div>
@@ -677,7 +631,7 @@ function ContentStep({
         canContinue={!saving && !gen.isStreaming}
         continueLabel={saving ? 'Saving...' : 'Continue'}
       />
-    </WizardShell>
+    </StepShell>
   )
 }
 
@@ -709,7 +663,6 @@ function CharactersStep({
   setCharacters,
   onContinue,
   onBack,
-  onSkip,
   storyDesc,
 }: {
   storyId: string
@@ -717,7 +670,6 @@ function CharactersStep({
   setCharacters: (chars: CharData[]) => void
   onContinue: () => void
   onBack: () => void
-  onSkip: () => void
   storyDesc: string
 }) {
   const queryClient = useQueryClient()
@@ -893,7 +845,7 @@ function CharactersStep({
   const isBusy = castGen.isStreaming || saving
 
   return (
-    <WizardShell step="characters" onSkip={onSkip}>
+    <StepShell step="characters">
       <div className="space-y-5">
 
         {/* Character list */}
@@ -963,9 +915,9 @@ function CharactersStep({
                         )}
                       </div>
                       {char.description && char.description !== char.name && (
-                        <p className="text-xs text-muted-foreground mt-0.5 line-clamp-2 font-prose">
+                        <Caption className="mt-0.5 line-clamp-2">
                           {char.description}
-                        </p>
+                        </Caption>
                       )}
                     </div>
                     <div className="flex gap-1 opacity-0 group-hover:opacity-100 transition-opacity shrink-0">
@@ -1004,9 +956,9 @@ function CharactersStep({
             >
               <Users className="size-5 text-primary/60 mb-3" />
               <div className="font-display text-base italic">Generate a Cast</div>
-              <p className="text-xs text-muted-foreground mt-1 leading-relaxed">
+              <Hint className="mt-1 leading-relaxed">
                 Let AI suggest characters that fit your story
-              </p>
+              </Hint>
             </button>
             <button
               onClick={() => setPhase('manual')}
@@ -1014,9 +966,9 @@ function CharactersStep({
             >
               <Plus className="size-5 text-muted-foreground mb-3" />
               <div className="font-display text-base italic">Add One by One</div>
-              <p className="text-xs text-muted-foreground mt-1 leading-relaxed">
+              <Hint className="mt-1 leading-relaxed">
                 Create characters manually with name and description
-              </p>
+              </Hint>
             </button>
           </div>
         )}
@@ -1072,9 +1024,9 @@ function CharactersStep({
                     />
                     <div className="flex-1 min-w-0">
                       <span className="text-sm font-medium">{char.name}</span>
-                      <p className="text-xs text-muted-foreground mt-0.5 font-prose">
+                      <Caption className="mt-0.5">
                         {char.description}
-                      </p>
+                      </Caption>
                     </div>
                   </label>
                 ))}
@@ -1179,7 +1131,7 @@ function CharactersStep({
         onContinue={onContinue}
         canContinue={!isBusy && editingIndex === null && !showCastPreview}
       />
-    </WizardShell>
+    </StepShell>
   )
 }
 
@@ -1189,12 +1141,10 @@ function PreferencesStep({
   storyId,
   onContinue,
   onBack,
-  onSkip,
 }: {
   storyId: string
   onContinue: () => void
   onBack: () => void
-  onSkip: () => void
 }) {
   const queryClient = useQueryClient()
   const { data: story } = useQuery({
@@ -1216,7 +1166,7 @@ function PreferencesStep({
   const hierarchicalSummary = story?.settings.enableHierarchicalSummary ?? true
 
   return (
-    <WizardShell step="preferences" onSkip={onSkip}>
+    <StepShell step="preferences">
       <div className="space-y-8">
 
         {/* ── Librarian ── */}
@@ -1226,11 +1176,11 @@ function PreferencesStep({
               <BookOpen className="size-4 text-primary/50" />
               <h3 className="text-sm font-medium text-foreground/80">The Librarian</h3>
             </div>
-            <p className="font-prose text-xs text-muted-foreground leading-relaxed">
+            <Hint className="font-prose leading-relaxed">
               After each generation, a background AI reads what was written and tracks
               characters, locations, plot points, and contradictions &mdash; building
               a living reference for your world.
-            </p>
+            </Hint>
           </div>
 
           <div className="grid grid-cols-2 gap-3">
@@ -1274,10 +1224,10 @@ function PreferencesStep({
               <Layers className="size-4 text-primary/50" />
               <h3 className="text-sm font-medium text-foreground/80">Context management</h3>
             </div>
-            <p className="font-prose text-xs text-muted-foreground leading-relaxed">
+            <Hint className="font-prose leading-relaxed">
               Controls how your fragments, prose, and instructions are assembled
               into the prompt that the AI sees when generating.
-            </p>
+            </Hint>
           </div>
 
           <div className="grid grid-cols-2 gap-3">
@@ -1321,10 +1271,10 @@ function PreferencesStep({
               <PenLine className="size-4 text-primary/50" />
               <h3 className="text-sm font-medium text-foreground/80">Generation mode</h3>
             </div>
-            <p className="font-prose text-xs text-muted-foreground leading-relaxed">
+            <Hint className="font-prose leading-relaxed">
               The prewriter analyzes your full context first and creates a focused
               brief for the writer &mdash; better character voices, pacing, and continuity.
-            </p>
+            </Hint>
           </div>
 
           <div className="grid grid-cols-2 gap-3">
@@ -1368,10 +1318,10 @@ function PreferencesStep({
               <Layers className="size-4 text-primary/50" />
               <h3 className="text-sm font-medium text-foreground/80">Hierarchical summaries</h3>
             </div>
-            <p className="font-prose text-xs text-muted-foreground leading-relaxed">
+            <Hint className="font-prose leading-relaxed">
               Older prose is progressively summarized so the AI can remember more of
               your story without running out of context space.
-            </p>
+            </Hint>
           </div>
 
           <div className="grid grid-cols-2 gap-3">
@@ -1417,7 +1367,7 @@ function PreferencesStep({
         onBack={onBack}
         onContinue={onContinue}
       />
-    </WizardShell>
+    </StepShell>
   )
 }
 
@@ -1430,7 +1380,6 @@ function CompleteStep({
   proseId,
   onComplete,
   onBack,
-  onSkip,
 }: {
   guidelineId: string | null
   worldId: string | null
@@ -1438,7 +1387,6 @@ function CompleteStep({
   proseId: string | null
   onComplete: () => void
   onBack: () => void
-  onSkip: () => void
 }) {
   const savedCharacters = characters.filter(c => c.fragmentId)
   const items = [
@@ -1449,7 +1397,7 @@ function CompleteStep({
   ].filter(Boolean) as { label: string; type: string }[]
 
   return (
-    <WizardShell step="complete" onSkip={onSkip}>
+    <StepShell step="complete">
       <div className="space-y-6">
         {items.length > 0 ? (
           <div className="space-y-2">
@@ -1467,9 +1415,9 @@ function CompleteStep({
             ))}
           </div>
         ) : (
-          <p className="text-sm text-muted-foreground font-prose italic">
+          <EmptyHint size="sm" className="font-prose">
             No fragments created yet &mdash; you can always add them later from the sidebar.
-          </p>
+          </EmptyHint>
         )}
 
       </div>
@@ -1479,7 +1427,7 @@ function CompleteStep({
         onContinue={onComplete}
         continueLabel="Start Writing"
       />
-    </WizardShell>
+    </StepShell>
   )
 }
 
@@ -1554,9 +1502,22 @@ export function StoryWizard({ storyId, onComplete }: StoryWizardProps) {
 
   const goTo = (s: WizardStep) => setStep(s)
 
-  switch (step) {
-    case 'concept':
-      return (
+  // Progress indicator counts only content-producing steps.
+  const countedIndex = COUNTED_STEPS.indexOf(step as (typeof COUNTED_STEPS)[number])
+  const showProgress = countedIndex >= 0
+
+  return (
+    <Wizard step={step} total={COUNTED_STEPS.length} onClose={onComplete}>
+      <Wizard.Toolbar>
+        {showProgress ? (
+          <Wizard.Progress current={countedIndex + 1} total={COUNTED_STEPS.length} />
+        ) : (
+          <span />
+        )}
+        <Wizard.SkipButton onClick={onComplete} />
+      </Wizard.Toolbar>
+
+      <Wizard.Step stepKey="concept">
         <ConceptStep
           storyId={storyId}
           storyName={storyName}
@@ -1564,12 +1525,10 @@ export function StoryWizard({ storyId, onComplete }: StoryWizardProps) {
           storyDesc={storyDesc}
           setStoryDesc={setStoryDesc}
           onContinue={() => goTo('guideline')}
-          onSkip={onComplete}
         />
-      )
+      </Wizard.Step>
 
-    case 'guideline':
-      return (
+      <Wizard.Step stepKey="guideline">
         <ContentStep
           key="guideline"
           storyId={storyId}
@@ -1580,13 +1539,11 @@ export function StoryWizard({ storyId, onComplete }: StoryWizardProps) {
           onSaved={id => setGuidelineId(id)}
           onContinue={() => goTo('world')}
           onBack={() => goTo('concept')}
-          onSkip={onComplete}
           storyDesc={storyDesc}
         />
-      )
+      </Wizard.Step>
 
-    case 'world':
-      return (
+      <Wizard.Step stepKey="world">
         <ContentStep
           key="world"
           storyId={storyId}
@@ -1597,36 +1554,30 @@ export function StoryWizard({ storyId, onComplete }: StoryWizardProps) {
           onSaved={id => setWorldId(id)}
           onContinue={() => goTo('characters')}
           onBack={() => goTo('guideline')}
-          onSkip={onComplete}
           storyDesc={storyDesc}
         />
-      )
+      </Wizard.Step>
 
-    case 'characters':
-      return (
+      <Wizard.Step stepKey="characters">
         <CharactersStep
           storyId={storyId}
           characters={characters}
           setCharacters={setCharacters}
           onContinue={() => goTo('preferences')}
           onBack={() => goTo('world')}
-          onSkip={onComplete}
           storyDesc={storyDesc}
         />
-      )
+      </Wizard.Step>
 
-    case 'preferences':
-      return (
+      <Wizard.Step stepKey="preferences">
         <PreferencesStep
           storyId={storyId}
           onContinue={() => goTo('prose')}
           onBack={() => goTo('characters')}
-          onSkip={onComplete}
         />
-      )
+      </Wizard.Step>
 
-    case 'prose':
-      return (
+      <Wizard.Step stepKey="prose">
         <ContentStep
           key="prose"
           storyId={storyId}
@@ -1637,13 +1588,11 @@ export function StoryWizard({ storyId, onComplete }: StoryWizardProps) {
           onSaved={id => setProseId(id)}
           onContinue={() => goTo('complete')}
           onBack={() => goTo('characters')}
-          onSkip={onComplete}
           storyDesc={storyDesc}
         />
-      )
+      </Wizard.Step>
 
-    case 'complete':
-      return (
+      <Wizard.Step stepKey="complete">
         <CompleteStep
           guidelineId={guidelineId}
           worldId={worldId}
@@ -1651,8 +1600,8 @@ export function StoryWizard({ storyId, onComplete }: StoryWizardProps) {
           proseId={proseId}
           onComplete={onComplete}
           onBack={() => goTo('prose')}
-          onSkip={onComplete}
         />
-      )
-  }
+      </Wizard.Step>
+    </Wizard>
+  )
 }

--- a/src/server/llm/agents.ts
+++ b/src/server/llm/agents.ts
@@ -11,11 +11,11 @@ import {
   WRITER_BRIEF_TOOLS_SUFFIX,
 } from './instruction-texts'
 
-function capitalize(s: string): string {
+export function capitalize(s: string): string {
   return s.charAt(0).toUpperCase() + s.slice(1)
 }
 
-function pluralize(name: string): string {
+export function pluralize(name: string): string {
   const massNouns = ['prose', 'knowledge']
   return massNouns.includes(name.toLowerCase()) ? name : name + 's'
 }

--- a/src/server/llm/tools.ts
+++ b/src/server/llm/tools.ts
@@ -16,6 +16,7 @@ import { createLogger } from '../logging'
 import type { Fragment } from '../fragments/schema'
 import { generateFragmentId } from '@/lib/fragment-ids'
 import { checkFragmentWrite, isFragmentLocked } from '../fragments/protection'
+import { capitalize, pluralize } from './agents'
 
 const logger = createLogger('llm-tools')
 const TOOL_LOG_MAX_CHARS = 1200
@@ -72,16 +73,6 @@ function withToolLogging<TInput, TResult>(
       throw error
     }
   }
-}
-
-function capitalize(s: string): string {
-  return s.charAt(0).toUpperCase() + s.slice(1)
-}
-
-function pluralize(name: string): string {
-  const massNouns = ['prose', 'knowledge']
-  if (massNouns.includes(name.toLowerCase())) return name
-  return name + 's'
 }
 
 export interface FragmentToolsOptions {

--- a/src/styles.css
+++ b/src/styles.css
@@ -443,6 +443,23 @@ code {
   animation: wisp-gradient 4s ease infinite;
 }
 
+/* ── Spinner (quiet, used by <Spinner>) ──────────────── */
+
+@keyframes spinner-rotate {
+  to { transform: rotate(360deg); }
+}
+
+@utility animate-spinner-rotate {
+  animation: spinner-rotate 1.1s linear infinite;
+  transform-origin: center;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .animate-spinner-rotate {
+    animation: none;
+  }
+}
+
 /* ── Character mention preview ───────────────────────── */
 
 .mention-preview-fade {


### PR DESCRIPTION
## Summary

`src/server/llm/tools.ts` and `src/server/llm/agents.ts` each defined identical `capitalize` and `pluralize` helpers. The two `pluralize` bodies differed only in style (ternary vs `if`-return) — behavior is identical for all inputs.

- `src/server/llm/agents.ts` now owns the helpers and exports them.
- `src/server/llm/tools.ts` imports them from `./agents`.

**Line delta:** -12 / +3 (net -9 across both files).

## Out-of-scope duplicate (noted, not changed)

`src/components/sidebar/SettingsPanel.tsx` also has its own local `capitalize` / `pluralize`. That's a client component outside this unit's file list and not in the LLM module, so it was left for a future dedup pass.

## Test plan

- [x] `bun run test` — 622/622 pass across 49 files
- [x] Pre-flight grep confirmed helpers only existed in these two files in `src/server/llm/`
- [x] No circular import introduced (`agents.ts` does not import `tools.ts` directly or transitively)