### PR TITLE
refactor(routes): extract withStory handler wrapper

### DIFF
--- a/src/server/routes/_helpers.ts
+++ b/src/server/routes/_helpers.ts
@@ -1,0 +1,27 @@
+import { getStory } from '../fragments/storage'
+import type { StoryMeta } from '../fragments/schema'
+
+type StoryCtx = {
+  params: { storyId: string }
+  set: { status?: number | string }
+  [key: string]: unknown
+}
+
+/**
+ * Wraps an Elysia handler with the "get story, 404 if missing" preamble.
+ * The inner handler receives the resolved story plus the original Elysia
+ * context (body/query/etc are preserved via structural typing).
+ */
+export function withStory<R>(
+  dataDir: string,
+  handler: (story: StoryMeta, ctx: any) => R | Promise<R>,
+): (ctx: StoryCtx) => Promise<R | { error: string }> {
+  return async (ctx) => {
+    const story = await getStory(dataDir, ctx.params.storyId)
+    if (!story) {
+      ctx.set.status = 404
+      return { error: 'Story not found' }
+    }
+    return handler(story, ctx)
+  }
+}

--- a/src/server/routes/agent-blocks.ts
+++ b/src/server/routes/agent-blocks.ts
@@ -1,5 +1,5 @@
 import { Elysia } from 'elysia'
-import { getStory } from '../fragments/storage'
+import { withStory } from './_helpers'
 import { agentBlockRegistry } from '../agents/agent-block-registry'
 import { modelRoleRegistry } from '../agents/model-role-registry'
 import { ensureCoreAgentsRegistered } from '../agents/register-core'
@@ -22,6 +22,9 @@ import {
 } from '../agents/agent-block-storage'
 
 export function agentBlockRoutes(dataDir: string) {
+  // Idempotent; run once so every handler sees a populated registry.
+  ensureCoreAgentsRegistered()
+
   return new Elysia({ detail: { tags: ['Agent Blocks'] } })
     // List currently running agents for a story
     .get('/stories/:storyId/active-agents', ({ params }) => {
@@ -30,12 +33,10 @@ export function agentBlockRoutes(dataDir: string) {
 
     // List all registered model roles (auto-discovered from agents)
     .get('/model-roles', () => {
-      ensureCoreAgentsRegistered()
       return modelRoleRegistry.list()
     }, { detail: { summary: 'List all registered model roles' } })
     // List all registered agent block definitions (auto-discovered)
     .get('/agent-blocks', () => {
-      ensureCoreAgentsRegistered()
       return agentBlockRegistry.list().map(def => ({
         agentName: def.agentName,
         displayName: def.displayName,
@@ -45,14 +46,7 @@ export function agentBlockRoutes(dataDir: string) {
     }, { detail: { summary: 'List all agent block definitions' } })
 
     // Export a single agent's block config for sharing
-    .get('/stories/:storyId/agent-blocks/:agentName/export-config', async ({ params, set }) => {
-      ensureCoreAgentsRegistered()
-      const story = await getStory(dataDir, params.storyId)
-      if (!story) {
-        set.status = 404
-        return { error: 'Story not found' }
-      }
-
+    .get('/stories/:storyId/agent-blocks/:agentName/export-config', withStory(dataDir, async (_story, { params, set }) => {
       const def = agentBlockRegistry.get(params.agentName)
       if (!def) {
         set.status = 404
@@ -65,17 +59,10 @@ export function agentBlockRoutes(dataDir: string) {
         displayName: def.displayName,
         config,
       }
-    }, { detail: { summary: 'Export a single agent block config' } })
+    }), { detail: { summary: 'Export a single agent block config' } })
 
     // Import a single agent's block config
-    .post('/stories/:storyId/agent-blocks/:agentName/import-config', async ({ params, body, set }) => {
-      ensureCoreAgentsRegistered()
-      const story = await getStory(dataDir, params.storyId)
-      if (!story) {
-        set.status = 404
-        return { error: 'Story not found' }
-      }
-
+    .post('/stories/:storyId/agent-blocks/:agentName/import-config', withStory(dataDir, async (_story, { params, body, set }) => {
       const def = agentBlockRegistry.get(params.agentName)
       if (!def) {
         set.status = 404
@@ -96,16 +83,10 @@ export function agentBlockRoutes(dataDir: string) {
 
       await saveAgentBlockConfig(dataDir, params.storyId, params.agentName, parsed.data)
       return { ok: true }
-    }, { detail: { summary: 'Import a single agent block config' } })
+    }), { detail: { summary: 'Import a single agent block config' } })
 
     // Get config + builtin blocks + available tools for an agent
-    .get('/stories/:storyId/agent-blocks/:agentName', async ({ params, set }) => {
-      const story = await getStory(dataDir, params.storyId)
-      if (!story) {
-        set.status = 404
-        return { error: 'Story not found' }
-      }
-
+    .get('/stories/:storyId/agent-blocks/:agentName', withStory(dataDir, async (_story, { params, set }) => {
       const def = agentBlockRegistry.get(params.agentName)
       if (!def) {
         set.status = 404
@@ -131,16 +112,10 @@ export function agentBlockRoutes(dataDir: string) {
         builtinBlocks,
         availableTools: def.availableTools ?? [],
       }
-    }, { detail: { summary: 'Get agent config and builtin blocks' } })
+    }), { detail: { summary: 'Get agent config and builtin blocks' } })
 
     // Compile preview with real story data
-    .get('/stories/:storyId/agent-blocks/:agentName/preview', async ({ params, query, set }) => {
-      const story = await getStory(dataDir, params.storyId)
-      if (!story) {
-        set.status = 404
-        return { error: 'Story not found' }
-      }
-
+    .get('/stories/:storyId/agent-blocks/:agentName/preview', withStory(dataDir, async (_story, { params, query, set }) => {
       const def = agentBlockRegistry.get(params.agentName)
       if (!def) {
         set.status = 404
@@ -177,16 +152,10 @@ export function agentBlockRoutes(dataDir: string) {
         .map(b => ({ id: b.id, name: b.name ?? b.id, role: b.role }))
 
       return { messages, blocks: blocksMeta, blockCount: blocks.length }
-    }, { detail: { summary: 'Preview compiled agent context' } })
+    }), { detail: { summary: 'Preview compiled agent context' } })
 
     // Create custom block
-    .post('/stories/:storyId/agent-blocks/:agentName/custom', async ({ params, body, set }) => {
-      const story = await getStory(dataDir, params.storyId)
-      if (!story) {
-        set.status = 404
-        return { error: 'Story not found' }
-      }
-
+    .post('/stories/:storyId/agent-blocks/:agentName/custom', withStory(dataDir, async (_story, { params, body, set }) => {
       const def = agentBlockRegistry.get(params.agentName)
       if (!def) {
         set.status = 404
@@ -201,16 +170,10 @@ export function agentBlockRoutes(dataDir: string) {
 
       const config = await addAgentCustomBlock(dataDir, params.storyId, params.agentName, parsed.data)
       return config
-    }, { detail: { summary: 'Create a custom agent block' } })
+    }), { detail: { summary: 'Create a custom agent block' } })
 
     // Update custom block
-    .put('/stories/:storyId/agent-blocks/:agentName/custom/:blockId', async ({ params, body, set }) => {
-      const story = await getStory(dataDir, params.storyId)
-      if (!story) {
-        set.status = 404
-        return { error: 'Story not found' }
-      }
-
+    .put('/stories/:storyId/agent-blocks/:agentName/custom/:blockId', withStory(dataDir, async (_story, { params, body, set }) => {
       const def = agentBlockRegistry.get(params.agentName)
       if (!def) {
         set.status = 404
@@ -223,16 +186,10 @@ export function agentBlockRoutes(dataDir: string) {
         return { error: 'Custom block not found' }
       }
       return config
-    }, { detail: { summary: 'Update a custom agent block' } })
+    }), { detail: { summary: 'Update a custom agent block' } })
 
     // Delete custom block
-    .delete('/stories/:storyId/agent-blocks/:agentName/custom/:blockId', async ({ params, set }) => {
-      const story = await getStory(dataDir, params.storyId)
-      if (!story) {
-        set.status = 404
-        return { error: 'Story not found' }
-      }
-
+    .delete('/stories/:storyId/agent-blocks/:agentName/custom/:blockId', withStory(dataDir, async (_story, { params, set }) => {
       const def = agentBlockRegistry.get(params.agentName)
       if (!def) {
         set.status = 404
@@ -241,16 +198,10 @@ export function agentBlockRoutes(dataDir: string) {
 
       const config = await deleteAgentCustomBlock(dataDir, params.storyId, params.agentName, params.blockId)
       return config
-    }, { detail: { summary: 'Delete a custom agent block' } })
+    }), { detail: { summary: 'Delete a custom agent block' } })
 
     // Update overrides / blockOrder / disabledTools
-    .patch('/stories/:storyId/agent-blocks/:agentName/config', async ({ params, body, set }) => {
-      const story = await getStory(dataDir, params.storyId)
-      if (!story) {
-        set.status = 404
-        return { error: 'Story not found' }
-      }
-
+    .patch('/stories/:storyId/agent-blocks/:agentName/config', withStory(dataDir, async (_story, { params, body, set }) => {
       const def = agentBlockRegistry.get(params.agentName)
       if (!def) {
         set.status = 404
@@ -280,15 +231,12 @@ export function agentBlockRoutes(dataDir: string) {
         await updateAgentDisabledTools(dataDir, params.storyId, params.agentName, disabledTools)
       }
 
-      // Apply disableAutoAnalysis if provided
+      const config = await getAgentBlockConfig(dataDir, params.storyId, params.agentName)
       if (disableAutoAnalysis !== undefined) {
-        const current = await getAgentBlockConfig(dataDir, params.storyId, params.agentName)
-        current.disableAutoAnalysis = disableAutoAnalysis
-        await saveAgentBlockConfig(dataDir, params.storyId, params.agentName, current)
+        config.disableAutoAnalysis = disableAutoAnalysis
+        await saveAgentBlockConfig(dataDir, params.storyId, params.agentName, config)
       }
 
-      // Return latest config
-      const config = await getAgentBlockConfig(dataDir, params.storyId, params.agentName)
       return config
-    }, { detail: { summary: 'Update agent block config' } })
+    }), { detail: { summary: 'Update agent block config' } })
 }

--- a/src/server/routes/branches.ts
+++ b/src/server/routes/branches.ts
@@ -1,5 +1,5 @@
 import { Elysia, t } from 'elysia'
-import { getStory } from '../fragments/storage'
+import { withStory } from './_helpers'
 import {
   getBranchesIndex,
   switchActiveBranch,
@@ -10,23 +10,13 @@ import {
 
 export function branchRoutes(dataDir: string) {
   return new Elysia({ detail: { tags: ['Branches'] } })
-    .get('/stories/:storyId/branches', async ({ params, set }) => {
-      const story = await getStory(dataDir, params.storyId)
-      if (!story) {
-        set.status = 404
-        return { error: 'Story not found' }
-      }
+    .get('/stories/:storyId/branches', withStory(dataDir, async (_story, { params }) => {
       return getBranchesIndex(dataDir, params.storyId)
-    }, {
+    }), {
       detail: { summary: 'List all branches' },
     })
 
-    .post('/stories/:storyId/branches', async ({ params, body, set }) => {
-      const story = await getStory(dataDir, params.storyId)
-      if (!story) {
-        set.status = 404
-        return { error: 'Story not found' }
-      }
+    .post('/stories/:storyId/branches', withStory(dataDir, async (_story, { params, body, set }) => {
       try {
         const branch = await createBranch(
           dataDir,
@@ -40,7 +30,7 @@ export function branchRoutes(dataDir: string) {
         set.status = 400
         return { error: err instanceof Error ? err.message : 'Failed to create branch' }
       }
-    }, {
+    }), {
       body: t.Object({
         name: t.String(),
         parentBranchId: t.String(),
@@ -49,12 +39,7 @@ export function branchRoutes(dataDir: string) {
       detail: { summary: 'Create a new branch' },
     })
 
-    .patch('/stories/:storyId/branches/active', async ({ params, body, set }) => {
-      const story = await getStory(dataDir, params.storyId)
-      if (!story) {
-        set.status = 404
-        return { error: 'Story not found' }
-      }
+    .patch('/stories/:storyId/branches/active', withStory(dataDir, async (_story, { params, body, set }) => {
       try {
         await switchActiveBranch(dataDir, params.storyId, body.branchId)
         return { ok: true }
@@ -62,19 +47,14 @@ export function branchRoutes(dataDir: string) {
         set.status = 400
         return { error: err instanceof Error ? err.message : 'Failed to switch branch' }
       }
-    }, {
+    }), {
       body: t.Object({
         branchId: t.String(),
       }),
       detail: { summary: 'Switch the active branch' },
     })
 
-    .put('/stories/:storyId/branches/:branchId', async ({ params, body, set }) => {
-      const story = await getStory(dataDir, params.storyId)
-      if (!story) {
-        set.status = 404
-        return { error: 'Story not found' }
-      }
+    .put('/stories/:storyId/branches/:branchId', withStory(dataDir, async (_story, { params, body, set }) => {
       try {
         const branch = await renameBranch(dataDir, params.storyId, params.branchId, body.name)
         return branch
@@ -82,19 +62,14 @@ export function branchRoutes(dataDir: string) {
         set.status = 400
         return { error: err instanceof Error ? err.message : 'Failed to rename branch' }
       }
-    }, {
+    }), {
       body: t.Object({
         name: t.String(),
       }),
       detail: { summary: 'Rename a branch' },
     })
 
-    .delete('/stories/:storyId/branches/:branchId', async ({ params, set }) => {
-      const story = await getStory(dataDir, params.storyId)
-      if (!story) {
-        set.status = 404
-        return { error: 'Story not found' }
-      }
+    .delete('/stories/:storyId/branches/:branchId', withStory(dataDir, async (_story, { params, set }) => {
       try {
         await deleteBranch(dataDir, params.storyId, params.branchId)
         return { ok: true }
@@ -102,7 +77,7 @@ export function branchRoutes(dataDir: string) {
         set.status = 400
         return { error: err instanceof Error ? err.message : 'Failed to delete branch' }
       }
-    }, {
+    }), {
       detail: { summary: 'Delete a branch' },
     })
 }


### PR DESCRIPTION
## Summary

Introduce a single `withStory(dataDir, handler)` wrapper in
`src/server/routes/_helpers.ts` that encapsulates the repeated
"fetch story / 404 if missing" Elysia preamble, and apply it to every
story-scoped handler in `agent-blocks.ts` and `branches.ts`.

### `withStory` call-site count: 13 (well over the 4-site threshold)

- `src/server/routes/branches.ts`: **5** callers
  (list, create, switch-active, rename, delete)
- `src/server/routes/agent-blocks.ts`: **8** callers
  (export-config, import-config, get, preview, POST custom,
  PUT custom, DELETE custom, PATCH config)

### Files migrated

- `src/server/routes/_helpers.ts` — new file, single export `withStory`
- `src/server/routes/agent-blocks.ts` — 8 handlers migrated
- `src/server/routes/branches.ts` — 5 handlers migrated

### Additional cleanups in `agent-blocks.ts`

- **Hoisted `ensureCoreAgentsRegistered()`** from four per-handler calls
  (`/model-roles`, `/agent-blocks`, `export-config`, `import-config`)
  to a single call at the top of `agentBlockRoutes(dataDir)`. It is
  idempotent (guarded by a module-level boolean), so running it once
  at module init is sufficient.
- **Fixed read-then-patch-then-read antipattern** in `PATCH /config`.
  Previously: read config, mutate `disableAutoAnalysis`, save, then
  re-read before returning. Now: read once, mutate in place (if
  supplied), save, return the same in-memory object.
  `saveAgentBlockConfig` writes atomically, so the returned object
  matches disk.

### Line delta

```
 src/server/routes/_helpers.ts     | 27 +++++++++++
 src/server/routes/agent-blocks.ts | 98 +++++++++------------------------------
 src/server/routes/branches.ts     | 47 +++++--------------
 3 files changed, 61 insertions(+), 111 deletions(-)
```

Net: **-50 lines** across the three files. No other files touched —
other route files with the same preamble (e.g. `blocks.ts`,
`librarian.ts`, `fragments.ts`, etc.) are explicitly out of scope for
this unit and will be migrated in a later pass.

### Behavior

No API surface changes. Same 404 response body (`{ error: 'Story not
found' }`), same status codes, same request/response shapes throughout.

## Test plan

- [x] `bun run test` — 622/622 passing (49 test files), including
  `tests/api/blocks-routes.test.ts` which exercises the agent-blocks
  endpoints (33 tests) and `tests/fragments/branches.test.ts` (23
  tests).
- [x] Existing 404 behavior for missing stories verified by
  `tests/api/blocks-routes.test.ts` ("returns 404 for missing story").