### PR TITLE
block create dialog window: add max height

### DIFF
--- a/src/components/blocks/BlockCreateDialog.tsx
+++ b/src/components/blocks/BlockCreateDialog.tsx
@@ -42,12 +42,12 @@ export function BlockCreateDialog({ open, onOpenChange, onSubmit }: BlockCreateD
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-[480px]" data-component-id="block-create-dialog">
+      <DialogContent className="sm:max-w-[480px] max-h-[85vh] flex flex-col overflow-hidden" data-component-id="block-create-dialog">
         <DialogHeader>
           <DialogTitle className="font-display text-lg">New Custom Block</DialogTitle>
         </DialogHeader>
 
-        <div className="space-y-5 py-1">
+        <div className="flex-1 overflow-y-auto space-y-5 py-1 pr-1">
           {/* Name */}
           <div>
             <h4 className="text-[0.5625rem] text-muted-foreground uppercase tracking-[0.15em] font-medium mb-2">
@@ -143,13 +143,13 @@ export function BlockCreateDialog({ open, onOpenChange, onSubmit }: BlockCreateD
                   : 'Block content...'
               }
               rows={6}
-              className={cn('text-xs resize-y', type === 'script' && 'font-mono bg-muted/15')}
+              className={cn('text-xs resize-y min-h-32 max-h-[40vh] overflow-y-auto', type === 'script' && 'font-mono bg-muted/15')}
               data-component-id="block-create-content"
             />
           </div>
         </div>
 
-        <DialogFooter className="gap-2">
+        <DialogFooter className="gap-2 pt-3 border-t border-border/30">
           <Button variant="ghost" onClick={() => onOpenChange(false)} className="text-xs" data-component-id="block-create-cancel">
             Cancel
           </Button>


### PR DESCRIPTION
Add max height for the text input when adding custom prompt blocks for agents, so its possible to press "Create Block" when pasting some big prompt
Before:
<img width="931" height="1710" alt="Screenshot 2026-04-17 181436" src="https://github.com/user-attachments/assets/83462709-0320-4ac6-bfad-194323a06d9f" />
After:
<img width="976" height="1368" alt="Screenshot 2026-04-17 182034" src="https://github.com/user-attachments/assets/935f5732-115f-43d5-a6c8-e8820f419be5" />
