### PR TITLE
fix(wizard): only persist cast members from fully-streamed lines

### DIFF
--- a/src/components/wizard/StoryWizard.tsx
+++ b/src/components/wizard/StoryWizard.tsx
@@ -582,7 +582,13 @@ function CharactersStep({
   // As the cast streams in, progressively append parsed rows.
   useEffect(() => {
     if (!castGen.text) return
-    const parsed = parseCastList(castGen.text)
+    // The last line is usually still streaming, so parse only up to the last newline
+    // (fully-terminated rows); once the stream ends, parse everything.
+    const source = castGen.isStreaming
+      ? castGen.text.slice(0, castGen.text.lastIndexOf('\n') + 1)
+      : castGen.text
+    if (!source) return
+    const parsed = parseCastList(source)
     if (parsed.length === 0) return
 
     const seen = seenStreamedNamesRef.current
@@ -616,7 +622,7 @@ function CharactersStep({
         queryClient.invalidateQueries({ queryKey: ['fragments', storyId] })
       }).catch(() => { /* best effort */ })
     }
-  }, [castGen.text]) // eslint-disable-line react-hooks/exhaustive-deps
+  }, [castGen.text, castGen.isStreaming]) // eslint-disable-line react-hooks/exhaustive-deps
 
   const handleSummon = () => {
     seenStreamedNamesRef.current = new Set(characters.map(c => c.name.toLowerCase()))


### PR DESCRIPTION
The cast-list parser ran on every stream tick, so it persisted a character as soon as the first word of its description arrived, capturing a half-streamed description that was never updated.

Now it parses only up to the last newline (fully-terminated rows) while streaming, then parses everything once the stream completes.

Fixes: #39 