### PR TITLE
feat: Docker build with idleTimeout patch via postbuild script

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,58 @@
+# Dependencies
+node_modules
+
+# Build output
+dist
+dist-ssr
+.nitro
+.tanstack
+.wrangler
+.output
+.vinxi
+
+# Git
+.git
+.gitignore
+
+# OS / editor
+.DS_Store
+*.swp
+*.swo
+*~
+.vscode
+
+# Environment
+.env
+.env.*
+
+# Data
+data/
+_data
+data_
+
+# Test artifacts
+junit.xml
+count.txt
+todos.json
+
+# Agent files
+AGENTS.md
+CLAUDE.md
+.agent/
+docs/site/
+.claude
+
+# Docs (not needed in production)
+docs/
+PLAN.md
+BACKEND-STRESSTEST.md
+FRONTEND-STRESSTEST.md
+README.md
+
+# Tests
+tests/
+
+# Windows / setup
+run.bat
+setup-dev.bat
+setup.ps1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,49 @@
+# syntax=docker/dockerfile:1
+
+# ── Build stage ──────────────────────────────────────────────────────────────
+FROM oven/bun:1-alpine AS build
+
+WORKDIR /app
+
+# Install build dependencies (alpine: glibc-compatible libs for native modules)
+RUN apk add --no-cache git
+
+# Copy package files and local SDK package first (layer caching)
+COPY package.json ./
+COPY packages/ packages/
+
+# Install all dependencies (including file: local packages)
+RUN bun install
+
+# Copy the rest of the source
+COPY . .
+
+# Build the app (TanStack Start → Nitro output in .output/)
+ARG BUILD_VERSION=unknown
+ENV BUILD_VERSION=${BUILD_VERSION}
+RUN bun run build
+
+# ── Production stage ─────────────────────────────────────────────────────────
+FROM oven/bun:1-alpine AS production
+
+LABEL org.opencontainers.image.source="https://github.com/tealios/errata"
+
+WORKDIR /app
+
+# Copy only the built output from the build stage
+COPY --from=build /app/.output /app/.output
+COPY --from=build /app/public /app/public
+COPY --from=build /app/plugins /app/plugins
+
+# Use the bun user (UID 1000) to match host user permissions
+USER bun
+
+ENV DATA_DIR=/app/data
+ENV PORT=7739
+
+EXPOSE ${PORT}
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+  CMD bun -e "fetch('http://localhost:' + process.env.PORT + '/api/health').then(r => { if (!r.ok) process.exit(1) }).catch(() => process.exit(1))"
+
+CMD ["bun", ".output/server/index.mjs"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,19 @@
+services:
+  errata:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        BUILD_VERSION: "${BUILD_VERSION:-dev}"
+    container_name: errata
+    restart: unless-stopped
+    ports:
+      - "${ERRATA_PORT:-7739}:7739"
+    environment:
+      - DATA_DIR=/app/data
+      - PORT=7739
+    volumes:
+      - errata-data:/app/data
+
+volumes:
+  errata-data:

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "docs:sync": "bun scripts/sync-docs-from-commits.ts",
     "preview": "bun install --frozen-lockfile && vite preview",
     "test": "bun install --frozen-lockfile && vitest run --config vitest.config.ts",
-    "test:watch": "bun install --frozen-lockfile && vitest --config vitest.config.ts"
+    "test:watch": "bun install --frozen-lockfile && vitest --config vitest.config.ts",
+    "postbuild": "bun scripts/postbuild.mjs"
   },
   "dependencies": {
     "@ai-sdk/openai-compatible": "^2.0.30",

--- a/scripts/postbuild.mjs
+++ b/scripts/postbuild.mjs
@@ -1,0 +1,18 @@
+// Patch the Nitro server to set Bun.serve idleTimeout (default 10s is too short
+// for LLM streaming endpoints). Nitro's srvx wraps Bun.serve and spreads
+// options.bun into serveOptions, but Nitro has no config key for this.
+import { readFileSync, writeFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const serverPath = resolve(__dirname, "../.output/server/index.mjs");
+
+const content = readFileSync(serverPath, "utf-8");
+const patched = content.replace(
+  /bun:\s*{\s*websocket:\s*void\s+0\s*}/,
+  "bun: { websocket: void 0, idleTimeout: 255 }",
+);
+
+writeFileSync(serverPath, patched, "utf-8");
+console.log("Patched idleTimeout in .output/server/index.mjs");


### PR DESCRIPTION
this commit adds two things:

- Dockerfile with fully working dockerized web version of errata
- idleTimeout patch

Some details about idleTimeout patch:

The issue is that if the provider is slow and the whole request takes more than 10 seconds, then it fails with `[Bun.serve]: request timed out after 10 seconds. Pass idleTimeout to configure.` on the stdout and "Error in input stream" in the UI.

The cause is that by default, bun's serve only has a 10 second timeout for the request. Because LLM streaming can be slow especially with long responses, tool calls or self hosting inference, it makes it unusable in some cases. Unfortunately Nitro v3 does not expose this setting (see https://github.com/nitrojs/nitro/issues/3454), it is only supported in v2 through an environment variable that does not work anymore in v3.

To solve this, I added a quick search and replace in post-build to monkey patch the parameter into the compiled js.